### PR TITLE
Switch to using new Tor Project dist URL.

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -47,7 +47,7 @@ class Common:
         self.tbl_version = tbl_version
 
         # initialize the app
-        self.default_mirror = 'https://www.torproject.org/dist/'
+        self.default_mirror = 'https://dist.torproject.org/'
         self.discover_arch_lang()
         self.build_paths()
         for d in self.paths['dirs']:


### PR DESCRIPTION
If I recall correctly, weasel (Tor Project's volunteer lead sysadmin)
tried to switch everything to using https://dist.torproject.org/ last
week, and then added an Apache redirect from
https://www.torproject.org/dist to https://dist.torproject.org after
discovering that some things were still trying to use the old URL. We
should switch to the new one, so that someday weasel can remove the
redirect.
- CHANGE `default_mirror` to https://dist.torproject.org/
