### PR TITLE
Fix opening new tab in already runned TBB

### DIFF
--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -634,10 +634,7 @@ class Launcher:
                 gtk.main_iteration_do(True)
 
         # run Tor Browser
-        if len(self.url_list) == 0:
-            subprocess.call([self.common.paths['tbb']['start']])
-        else:
-            subprocess.call([self.common.paths['tbb']['start'], '-allow-remote'] + self.url_list)
+        subprocess.call([self.common.paths['tbb']['start'], '-allow-remote'] + self.url_list)
 
         if run_next_task:
             self.run_task()


### PR DESCRIPTION
You should always pass `-allow-remote`. Otherwise new tab will work only if you pass some URL(s) on the first run.
