### PR TITLE
AppArmor: silence denied access to /sys/devices/virtual/block/*/uevent.

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -65,6 +65,7 @@
 
   /sys/devices/system/cpu/ r,
   /sys/devices/system/cpu/present r,
+  deny /sys/devices/virtual/block/*/uevent r,
 
   # Should use abstractions/gstreamer instead once merged upstream
   /etc/udev/udev.conf r,


### PR DESCRIPTION
I've not found any security-related usage of this kernel interface in the Tor
Browser source tree, and the browser seems to work just fine without having
access to it, so let's make AppArmor silently deny it.

Note that this doesn't change any existing behaviour: only logging is affected.