### PR TITLE
Get stable version using torbrowser updater xml

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -140,8 +140,8 @@ class Common:
                 'download_dir': tbb_cache+'/download',
                 'gnupg_homedir': tbb_local+'/gnupg_homedir',
                 'settings_file': tbb_config+'/settings',
-                'update_check_url': 'https://www.torproject.org/projects/torbrowser/RecommendedTBBVersions',
-                'update_check_file': tbb_cache+'/download/RecommendedTBBVersions',
+                'update_check_url': 'https://dist.torproject.org/torbrowser/update_2/release/Linux_x86_64-gcc3/x/en-US',
+                'update_check_file': tbb_cache+'/download/release.xml',
                 'tbb': {
                     'dir': tbb_local+'/tbb/'+self.architecture,
                     'dir_tbb': tbb_local+'/tbb/'+self.architecture+'/tor-browser_'+self.language,

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -34,6 +34,8 @@ from twisted.internet.protocol import Protocol
 from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.error import DNSLookupError
 
+import xml.etree.ElementTree as ET
+
 import OpenSSL
 
 import pygtk
@@ -488,38 +490,19 @@ class Launcher:
         subprocess.Popen([self.common.paths['tbl_bin']])
         self.destroy(False)
 
+    def get_stable_version(self):
+        tree = ET.parse(self.common.paths['update_check_file'])
+        for up in tree.getroot():
+            if up.tag == 'update' and up.attrib['appVersion']:
+                return up.attrib['appVersion']
+        return None
+
     def attempt_update(self):
         # load the update check file
         try:
-            versions = json.load(open(self.common.paths['update_check_file']))
-            latest = None
-
-            # filter linux versions
-            valid = []
-            for version in versions:
-                if '-Linux' in version:
-                    valid.append(str(version))
-            valid.sort()
-            if len(valid):
-                versions = valid
-
-            if len(versions) == 1:
-                latest = versions.pop()
-            else:
-                stable = []
-                # remove alphas/betas
-                for version in versions:
-                    if not re.search(r'a\d-Linux', version) and not re.search(r'b\d-Linux', version):
-                        stable.append(version)
-                if len(stable):
-                    latest = stable.pop()
-                else:
-                    latest = versions.pop()
-
+            latest = self.get_stable_version()
             if latest:
                 latest = str(latest)
-                if latest.endswith('-Linux'):
-                    latest = latest.rstrip('-Linux')
 
                 self.common.settings['latest_version'] = latest
                 self.common.settings['last_update_check_timestamp'] = int(time.time())


### PR DESCRIPTION
The RecommendedTBBVersions file contains current versions of Tor Browser
from all channels, including alpha or beta.

Instead of this, we can use xml file used by Tor Browser's updater in
the "release" channel:
https://dist.torproject.org/torbrowser/update_2/release/Linux_x86_64-gcc3/x/en-US