### PR TITLE
Remove /usr/local/ entries from sys.path before importing Twisted

### DIFF
--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -28,6 +28,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import os, sys, argparse
 
+# Hackaround for https://github.com/micahflee/torbrowser-launcher/issues/91
+# prevent packages installed by pip or setuptools from being read by
+# pkg_resources and tripping up apparmor
+sys.path = [dir for dir in sys.path if "/usr/local/" not in dir]
+
 from common import Common, SHARE
 from settings import Settings
 from launcher import Launcher

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -37,6 +37,10 @@ SHARE = os.getenv('TBL_SHARE', sys.prefix+'/share/torbrowser-launcher')
 import gettext
 gettext.install('torbrowser-launcher', os.path.join(SHARE, 'locale'))
 
+# Hackaround for https://github.com/micahflee/torbrowser-launcher/issues/91
+# prevent packages installed by pip or setuptools from being read by
+# pkg_resources and tripping up apparmor
+sys.path = [dir for dir in sys.path if "/usr/local/" not in dir]
 from twisted.internet import gtk2reactor
 gtk2reactor.install()
 

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -37,10 +37,6 @@ SHARE = os.getenv('TBL_SHARE', sys.prefix+'/share/torbrowser-launcher')
 import gettext
 gettext.install('torbrowser-launcher', os.path.join(SHARE, 'locale'))
 
-# Hackaround for https://github.com/micahflee/torbrowser-launcher/issues/91
-# prevent packages installed by pip or setuptools from being read by
-# pkg_resources and tripping up apparmor
-sys.path = [dir for dir in sys.path if "/usr/local/" not in dir]
 from twisted.internet import gtk2reactor
 gtk2reactor.install()
 


### PR DESCRIPTION
* Fixes: #91
* Prevents various things installed in /usr/local by pip and setuptools from
  tripping up TBL by annoying apparmor
* Side effect: breaks any installation of TBL into /usr/local/lib :/