### PR TITLE
Avoid re-downloading the tbb tarball if it is already present

### DIFF
--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -55,6 +55,7 @@ class Launcher:
     def __init__(self, common, url_list):
         self.common = common
         self.url_list = url_list
+        self.force_redownload = False
 
         # this is the current version of Tor Browser, which should get updated with every release
         self.min_version = '5.5.2'
@@ -260,7 +261,10 @@ class Launcher:
 
         elif task == 'download_tarball':
             print _('Downloading'), self.common.paths['tarball_url'].format(self.common.settings['mirror'])
-            self.download('tarball', self.common.paths['tarball_url'], self.common.paths['tarball_file'])
+            if not self.force_redownload and os.path.exists(self.common.paths['tarball_file']):
+                self.run_task()
+            else:
+                self.download('tarball', self.common.paths['tarball_url'], self.common.paths['tarball_file'])
 
         elif task == 'verify':
             print _('Verifying signature')
@@ -566,6 +570,7 @@ class Launcher:
 
     # start over and download TBB again
     def start_over(self):
+        self.force_redownload = True # Overwrite any existing file
         self.label.set_text(_("Downloading Tor Browser Bundle over again."))
         self.gui_tasks = ['download_tarball', 'verify', 'extract', 'run']
         self.gui_task_i = 0


### PR DESCRIPTION
Currently, any time the install directory is wiped the tarball is re-downloaded even if we already have it cached. At 50+ MB this is not ideal for us (can be slow) or the Tor project (extra server load). This change checks if the tarball already exists before downloading it again.

In the event that the version has been updated on the server or the tarball doesn't verify, the latest version will be downloaded again.

Some use cases that can benefit from this change, are sharing the tarball between users, sandboxing, and purging browser state periodically.