### PR TITLE
AppArmor: try to fix Tor Browser upgrade, again.

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -40,6 +40,7 @@
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/.** rwk,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/ rw,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** rw,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser.bak/ rwk,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser.bak/updated/ rwk,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/*.so mr,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/components/*.so mr,


### PR DESCRIPTION
This rule is apparently needed to allow the browser to complete its upgrade
process and restart after an update has been applied.

Closes: Debian#817267

https://github.com/micahflee/torbrowser-launcher/issues/227