### PR TITLE
Remove unused dependency of IPolicyForHTTPS

### DIFF
--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -30,7 +30,6 @@ import os, subprocess, time, json, tarfile, hashlib, lzma, threading, re, unicod
 from twisted.internet import reactor
 from twisted.web.client import Agent, RedirectAgent, ResponseDone, ResponseFailed
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IPolicyForHTTPS
 from twisted.internet.protocol import Protocol
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 


### PR DESCRIPTION
In d054f2a the certificate pinning was removed (#224) so IPolicyForHTTPS
is no longer requiered.  This is requiered to make torbrowser-launcher
work with python-twisted packages where IPolicyForHTTPS is not yet
implemented such as the one shipped with Ubuntu 14.04