### PR TITLE
Fix some minor nitpicks

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -28,9 +28,9 @@
   deny /etc/machine-id r,
   deny /var/lib/dbus/machine-id r,
 
-  @{PROC}/[0-9]*/mountinfo r,
-  @{PROC}/[0-9]*/stat r,
-  @{PROC}/[0-9]*/task/*/stat r,
+  owner @{PROC}/[0-9]*/mountinfo r,
+  owner @{PROC}/[0-9]*/stat r,
+  owner @{PROC}/[0-9]*/task/*/stat r,
   @{PROC}/sys/kernel/random/uuid r,
 
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/ r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -15,7 +15,7 @@
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/lock rwk,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/Tor,Lib}/*.so mr,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/Tor,Lib}/*.so.* mr,
-  @{PROC}/meminfo r,
+
   @{PROC}/sys/kernel/random/uuid r,
   /sys/devices/system/cpu/ r,
 

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -57,7 +57,7 @@ class Launcher:
         self.force_redownload = False
 
         # this is the current version of Tor Browser, which should get updated with every release
-        self.min_version = '5.5.2'
+        self.min_version = '6.0.2'
 
         # init launcher
         self.set_gui(None, '', [])


### PR DESCRIPTION
- The AppArmor profile let Firefox access information about processes from other users through `/proc`.
- `launcher.min_version` hadn't been bumped following the switch to 6.x.