### PR TITLE
AppArmor: deny access to DRM nodes (/dev/dri/*), to decrease attack surface a bit

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -83,6 +83,10 @@
   /sys/devices/pci[0-9]*/**/uevent r,
   owner /{dev,run}/shm/shmfd-* rw,
 
+  # Deny access to DRM nodes, that's granted by the X abstraction, which is
+  # sourced by the gnome abstraction, that we include.
+  deny /dev/dri/** rwklx,
+
   # KDE 4
   owner @{HOME}/.kde/share/config/* r,
 


### PR DESCRIPTION
References: https://labs.riseup.net/code/issues/11547

With this change applied, I could successfully test the
http://webglsamples.org/book/book.html WebGL demo.
