### PR TITLE
torbrowser-launcher: explicitly use python2 as interpreter

### DIFF
--- a/torbrowser-launcher
+++ b/torbrowser-launcher
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Tor Browser Launcher
 https://github.com/micahflee/torbrowser-launcher/


### PR DESCRIPTION
On some GNU/Linux distributions, python3 is the default python version
and thus causes issues when running torbrowser-launcher. This is a
stopgap until torbrowser-launcher is ported to python3 (#214).

Signed-off-by: Aleksa Sarai cyphar@cyphar.com
