### PR TITLE
Use GPGME Python bindings for GPG operations

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -196,7 +196,6 @@ class Common:
 
     def import_key_and_check_status(self, key):
         """Import a GnuPG key and check that the operation was successful.
-        
         :param str key: A string specifying the key's filepath from
             ``Common.paths``
         :rtype: bool
@@ -209,14 +208,14 @@ class Common:
             
             # try to gpg import key data
             impkey = self.paths['signing_keys'][key]
-            c.op_import(gpg.Data(file=impkey))
-            
+            if os.path.isfile(impkey):
+                c.op_import(gpg.Data(file=impkey))
+            else:
+                print _("Signing key not found")
+        
             # store import results, if any then return result
             result = c.op_import_result()
             if result:
-                assert not result.considered == 0
-                assert result.no_user_id == 0
-                assert result.not_imported == 0
                 return True
             else:
                 return False
@@ -224,7 +223,6 @@ class Common:
     # import gpg keys
     def import_keys(self):
         """Import all GnuPG keys.
-
         :rtype: bool
         :returns: ``True`` if all keys were successfully imported; ``False``
             otherwise.

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -196,16 +196,19 @@ class Common:
             # change home directory of current gpg context to torbrowser's gpg home
             c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.paths['gnupg_homedir'])
             
-            # try to gpg import key data
+            # store import keyfile full path
             impkey = self.paths['signing_keys'][key]
+            # check the keyfile exists before importing
             if os.path.isfile(impkey):
                 c.op_import(gpg.Data(file=impkey))
             else:
                 print _("Signing key not found")
         
-            # store import results, if any then return result
+            # store import results, if any
             result = c.op_import_result()
-            if result:
+            # if op_import_results returned results and the expected fingerprint
+            # is matched in the results, return true. Otherwise return false.
+            if (result and self.fingerprints[key] in result.imports[0].fpr):
                 return True
             else:
                 return False

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -196,16 +196,16 @@ class Common:
             c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.paths['gnupg_homedir'])
             
             impkey = self.paths['signing_keys'][key]
-            if os.path.isfile(impkey):
+            try:
                 c.op_import(gpg.Data(file=impkey))
-            else:
-                print _("Signing key not found")
-        
-            result = c.op_import_result()
-            if (result and self.fingerprints[key] in result.imports[0].fpr):
-                return True
-            else:
+            except:
                 return False
+            else:
+                result = c.op_import_result()
+                if (result and self.fingerprints[key] in result.imports[0].fpr):
+                    return True
+                else:
+                    return False
 
     # import gpg keys
     def import_keys(self):

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -193,21 +193,15 @@ class Common:
             previously and hasn't changed). ``False`` otherwise.
         """
         with gpg.Context() as c:
-            # change home directory of current gpg context to torbrowser's gpg home
             c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.paths['gnupg_homedir'])
             
-            # store import keyfile full path
             impkey = self.paths['signing_keys'][key]
-            # check the keyfile exists before importing
             if os.path.isfile(impkey):
                 c.op_import(gpg.Data(file=impkey))
             else:
                 print _("Signing key not found")
         
-            # store import results, if any
             result = c.op_import_result()
-            # if op_import_results returned results and the expected fingerprint
-            # is matched in the results, return true. Otherwise return false.
             if (result and self.fingerprints[key] in result.imports[0].fpr):
                 return True
             else:

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -40,16 +40,6 @@ gettext.install('torbrowser-launcher')
 from twisted.internet import gtk2reactor
 gtk2reactor.install()
 
-
-# We're looking for output which:
-#
-#   1. The first portion must be `[GNUPG:] IMPORT_OK`
-#   2. The second must be an integer between [0, 15], inclusive
-#   3. The third must be an uppercased hex-encoded 160-bit fingerprint
-gnupg_import_ok_pattern = re.compile(
-    "(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})")
-
-
 class Common:
 
     def __init__(self, tbl_version):

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -472,7 +472,7 @@ class Launcher:
 
                 return version
         return None
-    
+
     def verify(self):
         self.progressbar.set_fraction(0)
         self.progressbar.set_text(_('Verifying Signature'))

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -253,7 +253,8 @@ class Launcher:
 
         if task == 'download_version_check':
             print _('Downloading'), self.common.paths['version_check_url']
-            self.download('version check', self.common.paths['version_check_url'], self.common.paths['version_check_file'])
+            self.download('version check', self.common.paths['version_check_url'],
+                          self.common.paths['version_check_file'])
 
         if task == 'set_version':
             version = self.get_stable_version()
@@ -304,11 +305,23 @@ class Launcher:
 
                 if response.code != 200:
                     if common.settings['mirror'] != common.default_mirror:
-                        raise TryDefaultMirrorException((_("Download Error:") +  " {0} {1}\n\n" + _("You are currently using a non-default mirror") + ":\n{2}\n\n" + _("Would you like to switch back to the default?")).format(response.code, response.phrase, common.settings['mirror']))
+                        raise TryDefaultMirrorException(
+                            (_("Download Error:") + " {0} {1}\n\n" + _("You are currently using a non-default mirror")
+                             + ":\n{2}\n\n" + _("Would you like to switch back to the default?")).format(
+                                response.code, response.phrase, common.settings['mirror']
+                            )
+                        )
                     elif common.language != 'en-US' and not common.settings['force_en-US']:
-                        raise TryForcingEnglishException((_("Download Error:") + " {0} {1}\n\n" + _("Would you like to try the English version of Tor Browser instead?")).format(response.code, response.phrase))
+                        raise TryForcingEnglishException(
+                            (_("Download Error:") + " {0} {1}\n\n"
+                             + _("Would you like to try the English version of Tor Browser instead?")).format(
+                                response.code, response.phrase
+                            )
+                        )
                     else:
-                        raise DownloadErrorException((_("Download Error:") + " {0} {1}").format(response.code, response.phrase))
+                        raise DownloadErrorException(
+                            (_("Download Error:") + " {0} {1}").format(response.code, response.phrase)
+                        )
 
             def dataReceived(self, bytes):
                 self.file.write(bytes)
@@ -320,7 +333,7 @@ class Launcher:
                 for (size, unit) in [(1024 * 1024, "MiB"), (1024, "KiB")]:
                     if amount > size:
                         units = unit
-                        amount = amount / float(size)
+                        amount /= float(size)
                         break
 
                 self.progress.set_text(_('Downloaded')+(' %2.1f%% (%2.1f %s)' % ((percent * 100.0), amount, units)))
@@ -333,7 +346,9 @@ class Launcher:
         else:
             url = None
 
-        dl = FileDownloader(self.common, self.file_download, url, response.length, self.progressbar, self.response_finished)
+        dl = FileDownloader(
+            self.common, self.file_download, url, response.length, self.progressbar, self.response_finished
+        )
         response.deliverBody(dl)
 
     def response_finished(self, msg):
@@ -347,7 +362,7 @@ class Launcher:
 
         else:
             print "FINISHED", msg
-            ## FIXME handle errors
+            # FIXME handle errors
 
     def download_error(self, f):
         print _("Download Error:"), f.value, type(f.value)
@@ -371,7 +386,11 @@ class Launcher:
         elif isinstance(f.value, DNSLookupError):
             f.trap(DNSLookupError)
             if common.settings['mirror'] != common.default_mirror:
-                self.set_gui('error_try_default_mirror', (_("DNS Lookup Error") + "\n\n" + _("You are currently using a non-default mirror") + ":\n{0}\n\n" + _("Would you like to switch back to the default?")).format(common.settings['mirror']), [], False)
+                self.set_gui('error_try_default_mirror', (_("DNS Lookup Error") + "\n\n" +
+                                                          _("You are currently using a non-default mirror")
+                                                          + ":\n{0}\n\n"
+                                                          + _("Would you like to switch back to the default?")
+                                                          ).format(common.settings['mirror']), [], False)
             else:
                 self.set_gui('error', str(f.value), [], False)
 
@@ -380,9 +399,12 @@ class Launcher:
                 if isinstance(reason.value, OpenSSL.SSL.Error):
                     # TODO: add the ability to report attack by posting bug to trac.torproject.org
                     if not self.common.settings['download_over_tor']:
-                        self.set_gui('error_try_tor', _('The SSL certificate served by https://www.torproject.org is invalid! You may be under attack.') + " " + _('Try the download again using Tor?'), [], False)
+                        self.set_gui('error_try_tor',
+                                     _('The SSL certificate served by https://www.torproject.org is invalid! You may '
+                                       'be under attack.') + " " + _('Try the download again using Tor?'), [], False)
                     else:
-                        self.set_gui('error', _('The SSL certificate served by https://www.torproject.org is invalid! You may be under attack.'), [], False)
+                        self.set_gui('error', _('The SSL certificate served by https://www.torproject.org is invalid! '
+                                                'You may be under attack.'), [], False)
 
         elif isinstance(f.value, ConnectionRefusedError) and self.common.settings['download_over_tor']:
             # If we're using Tor, we'll only get this error when we fail to
@@ -405,7 +427,7 @@ class Launcher:
 
         # convert mirror_url from unicode to string, if needed (#205)
         if isinstance(mirror_url, unicode):
-            mirror_url = unicodedata.normalize('NFKD', mirror_url).encode('ascii','ignore')
+            mirror_url = unicodedata.normalize('NFKD', mirror_url).encode('ascii', 'ignore')
 
         # initialize the progress bar
         self.progressbar.set_fraction(0)
@@ -417,10 +439,10 @@ class Launcher:
             from twisted.internet.endpoints import clientFromString
             from txsocksx.http import SOCKS5Agent
 
-            torEndpoint = clientFromString(reactor, self.common.settings['tor_socks_address'])
+            torendpoint = clientFromString(reactor, self.common.settings['tor_socks_address'])
 
             # default mirror gets certificate pinning, only for requests that use the mirror
-            agent = SOCKS5Agent(reactor, proxyEndpoint=torEndpoint)
+            agent = SOCKS5Agent(reactor, proxyEndpoint=torendpoint)
         else:
             agent = Agent(reactor)
 
@@ -466,7 +488,7 @@ class Launcher:
                 version = str(up.attrib['appVersion'])
 
                 # make sure the version does not contain directory traversal attempts
-                # e.g. "5.5.3", "6.0a", "6.0a-hardned" are valid but "../../../../.." is invalid
+                # e.g. "5.5.3", "6.0a", "6.0a-hardened" are valid but "../../../../.." is invalid
                 if not re.match(r'^[a-z0-9\.\-]+$', version):
                     return None
 
@@ -477,9 +499,14 @@ class Launcher:
         self.progressbar.set_fraction(0)
         self.progressbar.set_text(_('Verifying Signature'))
         self.progressbar.show()
-        
-        def gui_raise_sigerror(self, error_string):
-            sigerror = "SIGNATURE VERIFICATION FAILED!\n\nError Code: " + error_string + "\n\nYou might be under attack, there might be a network\nproblem, or you may be missing a recently added\nTor Browser verification key.\n\nFor support, report the above error code.\nClick Start to try again."
+
+        def gui_raise_sigerror(self, sigerror='MissingErr'):
+            """
+            :type sigerror: str
+            """
+            sigerror = 'SIGNATURE VERIFICATION FAILED!\n\nError Code: {0}\n\nYou might be under attack, there might' \
+                       ' be a network\nproblem, or you may be missing a recently added\nTor Browser verification key.' \
+                       '\n\nFor support, report the above error code.\nClick Start to try again.'.format(sigerror)
             self.set_gui('task', sigerror, ['start_over'], False)
             self.clear_ui()
             self.build_ui()
@@ -548,7 +575,8 @@ class Launcher:
     def run(self, run_next_task=True):
         # don't run if it isn't at least the minimum version
         if not self.check_min_version():
-            message =  _("The version of Tor Browser you have installed is earlier than it should be, which could be a sign of an attack!")
+            message = _("The version of Tor Browser you have installed is earlier than it should be, which could be a "
+                        "sign of an attack!")
             print message
 
             md = gtk.MessageDialog(None, gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_WARNING, gtk.BUTTONS_CLOSE, _(message))
@@ -568,7 +596,10 @@ class Launcher:
                     sound.play()
                     time.sleep(10)
                 except ImportError:
-                    md = gtk.MessageDialog(None, gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_WARNING, gtk.BUTTONS_CLOSE, _("The python-pygame package is missing, the modem sound is unavailable."))
+                    md = gtk.MessageDialog(
+                        None, gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_WARNING, gtk.BUTTONS_CLOSE,
+                        _("The python-pygame package is missing, the modem sound is unavailable.")
+                    )
                     md.set_position(gtk.WIN_POS_CENTER)
                     md.run()
                     md.destroy()
@@ -597,7 +628,7 @@ class Launcher:
 
     # start over and download TBB again
     def start_over(self):
-        self.force_redownload = True # Overwrite any existing file
+        self.force_redownload = True  # Overwrite any existing file
         self.label.set_text(_("Downloading Tor Browser Bundle over again."))
         self.gui_tasks = ['download_tarball', 'verify', 'extract', 'run']
         self.gui_task_i = 0

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -500,7 +500,7 @@ class Launcher:
                     gui_raise_sigerror(self, str(e))
             else:
                 self.run_task()
-                
+
     def extract(self):
         # initialize the progress bar
         self.progressbar.set_fraction(0)

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -486,7 +486,7 @@ class Launcher:
             
             try:
                 c.verify(signature=sig, signed_data=signed)
-            except Exception as e:
+            except:
                 self.set_gui('task', _("SIGNATURE VERIFICATION FAILED!\n\nYou might be under attack, or there might just be a networking problem. Click Start try the download again."), ['start_over'], False)
                 self.clear_ui()
                 self.build_ui()


### PR DESCRIPTION
This PR modifies functions performing GnuPG (GPG) operations to utilize the [GPGME](https://www.gnupg.org/related_software/gpgme/index.html) Python bindings, rather than calling a user's GPG executable directly.

The new functions behave similarly to the old ones right now. However, more robust exception handling is now possible as more detailed and precise errors are returned. The GUI warning of a verify failure was made more detailed and specific to the nature of the failure.

Right now the *verify()* function performs the same action whether an error is raised due to a missing public key or a bad signature, but the conditions are now differentiated in the code, so it is a trivial matter to take different actions for either error now.

Additional feedback is needed on if we should attempt to find and import a missing signing key when encountered. It seemed obvious to do so at first, but for security reasons @micahflee may intend it to stay a manual process, so the behaviour was intentionally left the same for now, with the error details being passed on to the GUI pop-up.

See #262 