### PR TITLE
Add error handling for GPGME imports and add logic to shell out if the module is not present

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ Then install dependencies, build a package, and install:
 ### Debian, Ubuntu, Linux Mint, etc.
 
 ```sh
-sudo apt-get install build-essential dh-python python-all python-stdeb python-gtk2 python-twisted python-lzma python-txsocksx gnupg fakeroot xz-utils tor python-gpgme
+sudo apt-get install build-essential dh-python python-all python-stdeb python-gtk2 python-twisted python-lzma python-txsocksx gnupg fakeroot xz-utils tor python-gpg
 ./build_deb.sh
 sudo dpkg -i deb_dist/torbrowser-launcher_*.deb
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ Then install dependencies, build a package, and install:
 ### Debian, Ubuntu, Linux Mint, etc.
 
 ```sh
-sudo apt-get install build-essential dh-python python-all python-stdeb python-gtk2 python-twisted python-lzma python-txsocksx gnupg fakeroot xz-utils tor gpg
+sudo apt-get install build-essential dh-python python-all python-stdeb python-gtk2 python-twisted python-lzma python-txsocksx gnupg fakeroot xz-utils tor python-gpgme
 ./build_deb.sh
 sudo dpkg -i deb_dist/torbrowser-launcher_*.deb
 ```
@@ -33,4 +33,3 @@ Optionally you can install `pygame` if you want to play a modem sound while Tor 
 
 Install the dependencies: sadly, not all of them are available in virtualenv, so you will need to install (some of) them system-wide.
 Then, you can run: `TBL_SHARE=share ./torbrowser-launcher`
-

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package: torbrowser-launcher
-Depends: python-gtk2, python-twisted, python-lzma, python-gpg, gnupg, xz-utils
+Depends: python-gtk2, python-twisted, python-lzma, python-gpgme, gnupg, xz-utils
 Build-Depends: dh-python
 Recommends: python-pygame, python-txsocksx, tor
 Suite: trusty

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package: torbrowser-launcher
-Depends: python-gtk2, python-twisted, python-lzma, python-gpgme, gnupg, xz-utils
+Depends: python-gtk2, python-twisted, python-lzma, gnupg, xz-utils
 Build-Depends: dh-python
 Recommends: python-pygame, python-txsocksx, tor
 Suite: trusty

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -26,7 +26,23 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-import os, sys, platform, subprocess, locale, pickle, json, re, gpg
+import os
+import sys
+import platform
+import subprocess
+import locale
+import pickle
+import json
+import re
+
+try:
+    import gpg
+except ImportError:
+    try:
+        import gpgme as gpg
+    except ImportError:
+        gpg_support = False
+        print('You need the gpgme Python bindings installed to verify integrity of downloaded archives.')
 
 import pygtk
 pygtk.require('2.0')
@@ -202,7 +218,7 @@ class Common:
                 return False
             else:
                 result = c.op_import_result()
-                if (result and self.fingerprints[key] in result.imports[0].fpr):
+                if result and self.fingerprints[key] in result.imports[0].fpr:
                     return True
                 else:
                     return False

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -38,11 +38,7 @@ import re
 try:
     import gpg
 except ImportError:
-    try:
-        import gpgme as gpg
-    except ImportError:
-        gpg_support = False
-        print('You need the gpgme Python bindings installed to verify integrity of downloaded archives.')
+    gpgme_support = False
 
 import pygtk
 pygtk.require('2.0')
@@ -55,6 +51,15 @@ gettext.install('torbrowser-launcher')
 
 from twisted.internet import gtk2reactor
 gtk2reactor.install()
+
+# We're looking for output which:
+#
+#  1. The first portion must be `[GNUPG:] IMPORT_OK`
+#  2. The second must be an integer between [0, 15], inclusive
+#  3. The third must be an uppercased hex-encoded 160-bit fingerprint
+gnupg_import_ok_pattern = re.compile(
+    "(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})")
+
 
 class Common:
 
@@ -208,20 +213,38 @@ class Common:
         :returns: ``True`` if the key is now within the keyring (or was
             previously and hasn't changed). ``False`` otherwise.
         """
-        with gpg.Context() as c:
-            c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.paths['gnupg_homedir'])
-            
-            impkey = self.paths['signing_keys'][key]
-            try:
-                c.op_import(gpg.Data(file=impkey))
-            except:
-                return False
-            else:
-                result = c.op_import_result()
-                if result and self.fingerprints[key] in result.imports[0].fpr:
-                    return True
-                else:
+        if gpgme_support:
+            with gpg.Context() as c:
+                c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.paths['gnupg_homedir'])
+
+                impkey = self.paths['signing_keys'][key]
+                try:
+                    c.op_import(gpg.Data(file=impkey))
+                except:
                     return False
+                else:
+                    result = c.op_import_result()
+                    if result and self.fingerprints[key] in result.imports[0].fpr:
+                        return True
+                    else:
+                        return False
+        else:
+            success = False
+
+            p = subprocess.Popen(['/usr/bin/gpg', '--status-fd', '2',
+                                  '--homedir', self.paths['gnupg_homedir'],
+                                  '--import', self.paths['signing_keys'][key]],
+                                 stderr=subprocess.PIPE)
+            p.wait()
+
+            for output in p.stderr.readlines():
+                match = gnupg_import_ok_pattern.match(output)
+                if match:
+                    if match.group().find(self.fingerprints[key]) >= 0:
+                        success = True
+                        break
+
+            return success
 
     # import gpg keys
     def import_keys(self):

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -46,11 +46,7 @@ from twisted.internet.error import DNSLookupError, ConnectionRefusedError
 try:
     import gpg
 except ImportError:
-    try:
-        import gpgme as gpg
-    except ImportError:
-        gpg_support = False
-        print('You need the gpgme Python bindings installed to verify integrity of downloaded archives.')
+    gpgme_support = False
 
 import xml.etree.ElementTree as ET
 
@@ -60,17 +56,22 @@ import pygtk
 pygtk.require('2.0')
 import gtk
 
+
 class TryStableException(Exception):
     pass
+
 
 class TryDefaultMirrorException(Exception):
     pass
 
+
 class TryForcingEnglishException(Exception):
     pass
 
+
 class DownloadErrorException(Exception):
     pass
+
 
 class Launcher:
     def __init__(self, common, url_list):
@@ -529,23 +530,36 @@ class Launcher:
             self.set_gui('task', sigerror, ['start_over'], False)
             self.clear_ui()
             self.build_ui()
-        
-        with gpg.Context() as c:
-            c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.common.paths['gnupg_homedir'])
-            
-            sig = gpg.Data(file=self.common.paths['sig_file'])
-            signed = gpg.Data(file=self.common.paths['tarball_file'])
-            
-            try:
-                c.verify(signature=sig, signed_data=signed)
-            except gpg.errors.BadSignatures as e:
-                result = str(e).split(": ")
-                if result[1] == 'Bad signature':
-                    gui_raise_sigerror(self, str(e))
-                elif result[1] == 'No public key':
-                    gui_raise_sigerror(self, str(e))
-            else:
+
+        if gpgme_support:
+            with gpg.Context() as c:
+                c.set_engine_info(gpg.constants.protocol.OpenPGP, home_dir=self.common.paths['gnupg_homedir'])
+
+                sig = gpg.Data(file=self.common.paths['sig_file'])
+                signed = gpg.Data(file=self.common.paths['tarball_file'])
+
+                try:
+                    c.verify(signature=sig, signed_data=signed)
+                except gpg.errors.BadSignatures as e:
+                    result = str(e).split(": ")
+                    if result[1] == 'Bad signature':
+                        gui_raise_sigerror(self, str(e))
+                    elif result[1] == 'No public key':
+                        gui_raise_sigerror(self, str(e))
+                else:
+                    self.run_task()
+        else:
+            FNULL = open(os.devnull, 'w')
+            p = subprocess.Popen(['/usr/bin/gpg', '--homedir', self.common.paths['gnupg_homedir'], '--verify',
+                                  self.common.paths['sig_file'], self.common.paths['tarball_file']], stdout=FNULL,
+                                 stderr=subprocess.STDOUT)
+            self.pulse_until_process_exits(p)
+            if p.returncode == 0:
                 self.run_task()
+            else:
+                gui_raise_sigerror(self, 'VERIFY_FAIL_NO_GPGME')
+                if not reactor.running:
+                    reactor.run()
 
     def extract(self):
         # initialize the progress bar

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -26,12 +26,31 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-import os, subprocess, time, json, tarfile, hashlib, lzma, threading, re, unicodedata, gpg
+import os
+import subprocess
+import time
+import json
+import tarfile
+import hashlib
+import lzma
+import threading
+import re
+import unicodedata
+
 from twisted.internet import reactor
 from twisted.web.client import Agent, RedirectAgent, ResponseDone, ResponseFailed
 from twisted.web.http_headers import Headers
 from twisted.internet.protocol import Protocol
 from twisted.internet.error import DNSLookupError, ConnectionRefusedError
+
+try:
+    import gpg
+except ImportError:
+    try:
+        import gpgme as gpg
+    except ImportError:
+        gpg_support = False
+        print('You need the gpgme Python bindings installed to verify integrity of downloaded archives.')
 
 import xml.etree.ElementTree as ET
 


### PR DESCRIPTION
This PR adds error handling for the recently added GPGME module imports. If the correct GPGME module is not available on a system, the program will fall back to the legacy method of shelling out to the GPG executable.

I removed `python-gpg` from the stdeb.cfg file in order to prevent unresolvable dependencies, since the target Ubuntu suite is Trusty (14.04 LTS) and `python-gpg` doesn't exist in Ubuntu repositories until Zesty (17.04).

Fixes #267 regression from PR #266 