### PR TITLE
Apparmor: adjust profile for Tor Browser 7.0.1, support multiprocess Firefox, and various small maintenance changes

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -46,6 +46,7 @@
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/components/*.so mr,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/browser/components/*.so mr,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/firefox rix,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/plugin-container Pix,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{,TorBrowser/UpdateInfo/}updates/[0-9]*/updater ix,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{,TorBrowser/UpdateInfo/}updates/0/MozUpdater/bgupdate/updater ix,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profiles.ini r,
@@ -82,6 +83,9 @@
   /run/udev/data/+pci:* r,
   /sys/devices/pci[0-9]*/**/uevent r,
   owner /{dev,run}/shm/shmfd-* rw,
+
+  # Required for multiprocess Firefox (aka Electrolysis, i.e. e10s)
+  owner /dev/shm/org.chromium.* rw,
 
   # Deny access to DRM nodes, that's granted by the X abstraction, which is
   # sourced by the gnome abstraction, that we include.

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -28,9 +28,9 @@
   deny /etc/machine-id r,
   deny /var/lib/dbus/machine-id r,
 
-  owner @{PROC}/[0-9]*/mountinfo r,
-  owner @{PROC}/[0-9]*/stat r,
-  owner @{PROC}/[0-9]*/task/*/stat r,
+  owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/stat r,
+  owner @{PROC}/@{pid}/task/*/stat r,
   @{PROC}/sys/kernel/random/uuid r,
 
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/ r,

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -30,6 +30,7 @@
 
   owner @{PROC}/@{pid}/mountinfo r,
   owner @{PROC}/@{pid}/stat r,
+  owner @{PROC}/@{pid}/status r,
   owner @{PROC}/@{pid}/task/*/stat r,
   @{PROC}/sys/kernel/random/uuid r,
 

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -77,6 +77,8 @@
 
   /sys/devices/system/cpu/ r,
   /sys/devices/system/cpu/present r,
+  /sys/devices/system/node/ r,
+  /sys/devices/system/node/node[0-9]*/meminfo r,
   deny /sys/devices/virtual/block/*/uevent r,
 
   # Should use abstractions/gstreamer instead once merged upstream

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -91,6 +91,12 @@
   # sourced by the gnome abstraction, that we include.
   deny /dev/dri/** rwklx,
 
+  # Silence denial logs about permissions we don't need
+  deny /dev/dri/   rwklx,
+  deny @{PROC}/@{pid}/net/route r,
+  deny /sys/devices/system/cpu/cpufreq/policy[0-9]*/cpuinfo_max_freq r,
+  deny /sys/devices/system/cpu/*/cache/index[0-9]*/size r,
+
   # KDE 4
   owner @{HOME}/.kde/share/config/* r,
 


### PR DESCRIPTION
Here, I'm doing a first update & cleanup so I have a good starting point to work on sandboxing Tor Browser's content renderer processes more strictly: with this branch, we confine these processes in exactly the same way as the parent Firefox process. I'm pretty sure they could be confined much more strictly, without impacting UX whatsoever. And while we're at it, maybe some permissions we currently grant to the parent Firefox process are not needed anymore, as it does less work.
