### PR TITLE
Update version_check_url

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -168,7 +168,7 @@ class Common:
                 'gnupg_homedir': tbb_local+'/gnupg_homedir',
                 'settings_file': tbb_config+'/settings.json',
                 'settings_file_pickle': tbb_config+'/settings',
-                'version_check_url': 'https://dist.torproject.org/torbrowser/update_2/release/Linux_x86_64-gcc3/x/en-US',
+                'version_check_url': 'https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US',
                 'version_check_file': tbb_cache+'/download/release.xml',
                 'tbb': {
                     'dir': tbb_local+'/tbb/'+self.architecture,


### PR DESCRIPTION
The Tor Browser update manifests have been moved from
dist.torproject.org to aus1.torproject.org:
https://trac.torproject.org/projects/tor/ticket/19481

The update_2 part of the URL has been changed to update_3:
https://trac.torproject.org/projects/tor/ticket/19316