### PR TITLE
AppArmor: allow the tor process to modify its data directory.

### DIFF
--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -11,7 +11,7 @@
   /etc/passwd r,
   /etc/resolv.conf r,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Tor/tor mr,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/ r,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/ rw,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/* rw,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/lock rwk,
   owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/Tor,Lib}/*.so mr,


### PR DESCRIPTION
It's unclear to me why this is not needed _all the time_, but it does make sense
that at least in some circumstances, it needs to do that, e.g. to create
that directory.

Originally reported by Chris Lamb <lamby@debian.org> on
https://bugs.debian.org/876484.