### PR TITLE
AppArmor: silence the logs by explicitly denying access to a few forbidden directories

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -96,6 +96,10 @@
 
   # Silence denial logs about permissions we don't need
   deny /dev/dri/   rwklx,
+  deny @{HOME}/.cache/fontconfig/ rw,
+  deny @{HOME}/.cache/fontconfig/** rw,
+  deny @{HOME}/.config/gtk-2.0/ rw,
+  deny @{HOME}/.config/gtk-2.0/** rw,
   deny @{PROC}/@{pid}/net/route r,
   deny /sys/devices/system/cpu/cpufreq/policy[0-9]*/cpuinfo_max_freq r,
   deny /sys/devices/system/cpu/*/cache/index[0-9]*/size r,


### PR DESCRIPTION
Hi!

Tor Browser will always check for these directories and fail, meanwhile needlessly spamming the journal with audit log entries.

These changes were prepared by my Tails colleague anonym, and I hereby sign off them.

I've not verified that they fix anything in regular torbrowser-launcher installations (i.e. outside of Tails) but worst case I think they're just useless, harmless, and help us keep our delta with the upstream profile as small as possible.

