### PR TITLE
Split print calls on newlines

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -226,9 +226,11 @@ class Common:
             if match and match.group(2) == 'IMPORT_OK':
                 fingerprint = str(match.group(4))
                 if match.group(3) == '0':
-                    print('Keyring refreshed successfully...\n  No key updates for key: ' + fingerprint)
+                    print('Keyring refreshed successfully...')
+                    print('  No key updates for key: ' + fingerprint)
                 elif match.group(3) == '4':
-                    print('Keyring refreshed successfully...\n  New signatures for key: ' + fingerprint)
+                    print('Keyring refreshed successfully...')
+                    print('  New signatures for key: ' + fingerprint)
                 else:
                     print('Keyring refreshed successfully...')
 


### PR DESCRIPTION
If `torbrowser-launcher` cannot write to `stdout`, e.g. because it was started in the background and the controlling terminal has been closed or because it was started from a desktop environment launcher whose stdout has been closed, it crashes after updating the GnuPG key.

This is due to `print()` crashing the program if `stdout` isn't writeable and the string to print contains a newline.

To work around the problem, split the strings containing newlines into several calls to `print()`.

See also the upstream bug at https://bugs.python.org/issue32345

Closes #298