### PR TITLE
Use prefs.js to get installed torbrowser version

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -175,8 +175,8 @@ class Common:
                 'tbb': {
                     'dir': tbb_local+'/tbb/'+self.architecture,
                     'dir_tbb': tbb_local+'/tbb/'+self.architecture+'/tor-browser_'+self.language,
+                    'prefs': tbb_local+'/tbb/'+self.architecture+'/tor-browser_'+self.language+'/Browser/TorBrowser/Data/Browser/profile.default/prefs.js',
                     'start': tbb_local+'/tbb/'+self.architecture+'/tor-browser_'+self.language+'/start-tor-browser.desktop',
-                    'versions': tbb_local+'/tbb/'+self.architecture+'/tor-browser_'+self.language+'/Browser/TorBrowser/Docs/sources/versions',
                 },
             }
 

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -600,9 +600,9 @@ class Launcher:
 
     def check_min_version(self):
         installed_version = None
-        for line in open(self.common.paths['tbb']['versions']).readlines():
-            if line.startswith('TORBROWSER_VERSION='):
-                installed_version = line.split('=')[1].strip()
+        for line in open(self.common.paths['tbb']['prefs']).readlines():
+            if line.startswith('user_pref("browser.startup.homepage_override.torbrowser.version",'):
+                installed_version = line.split('"')[3]
                 break
 
         if self.min_version <= installed_version:


### PR DESCRIPTION
Browser/TorBrowser/Docs/sources/versions is no longer provided by
TorBrowser, so get the current version string from prefs.js instead.

This fixes issue #306.

Described in https://trac.torproject.org/projects/tor/ticket/25012#comment:8 as "a more robust kludge" than reading Changelog.txt :p