### PR TITLE
AppArmor profiles, 2018-01 edition

### DIFF
--- a/apparmor/local/torbrowser.Browser.firefox
+++ b/apparmor/local/torbrowser.Browser.firefox
@@ -1,2 +1,0 @@
-# Site-specific additions and overrides for torbrowser.Browser.firefox.
-# For more details, please see /etc/apparmor.d/local/README.

--- a/apparmor/local/torbrowser.Browser.firefox
+++ b/apparmor/local/torbrowser.Browser.firefox
@@ -1,2 +1,2 @@
 # Site-specific additions and overrides for torbrowser.Browser.firefox.
-# For more details, please see /etc/apparmor.d/local/README. 
+# For more details, please see /etc/apparmor.d/local/README.

--- a/apparmor/local/torbrowser.Browser.plugin-container
+++ b/apparmor/local/torbrowser.Browser.plugin-container
@@ -1,2 +1,0 @@
-# Site-specific additions and overrides for torbrowser.Browser.plugin-container.
-# For more details, please see /etc/apparmor.d/local/README.

--- a/apparmor/local/torbrowser.Tor.tor
+++ b/apparmor/local/torbrowser.Tor.tor
@@ -1,2 +1,0 @@
-# Site-specific additions and overrides for torbrowser.Tor.tor.
-# For more details, please see /etc/apparmor.d/local/README.

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -1,7 +1,9 @@
 #include <tunables/global>
 #include <tunables/torbrowser>
 
-/home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/firefox {
+@{torbrowser_firefox_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/firefox
+
+profile torbrowser_firefox @{torbrowser_firefox_executable} {
   #include <abstractions/gnome>
 
   # Uncomment the following lines if you want to give the Tor Browser read-write

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -49,6 +49,8 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   owner @{torbrowser_home_dir}.bak/ rwk,
   owner @{torbrowser_home_dir}.bak/** rwk,
   owner @{torbrowser_home_dir}/*.so mr,
+  owner @{torbrowser_home_dir}/.cache/fontconfig/ rwk,
+  owner @{torbrowser_home_dir}/.cache/fontconfig/** rwkl,
   owner @{torbrowser_home_dir}/components/*.so mr,
   owner @{torbrowser_home_dir}/browser/components/*.so mr,
   owner @{torbrowser_home_dir}/firefox rix,

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -13,7 +13,8 @@
   network netlink raw,
   network tcp,
 
-  ptrace (trace) peer=@{profile_name},
+  ptrace (trace) peer=torbrowser_plugin_container,
+  signal (send) set=("term") peer=torbrowser_plugin_container,
 
   deny /etc/host.conf r,
   deny /etc/hosts r,

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -108,6 +108,10 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   deny /sys/devices/system/cpu/cpufreq/policy[0-9]*/cpuinfo_max_freq r,
   deny /sys/devices/system/cpu/*/cache/index[0-9]*/size r,
 
+  # Silence denial logs about PulseAudio
+  deny /etc/pulse/client.conf r,
+  deny /usr/bin/pulseaudio x,
+
   # KDE 4
   owner @{HOME}/.kde/share/config/* r,
 

--- a/apparmor/torbrowser.Browser.plugin-container
+++ b/apparmor/torbrowser.Browser.plugin-container
@@ -24,6 +24,9 @@ profile torbrowser_plugin_container {
   deny /etc/machine-id r,
   deny /var/lib/dbus/machine-id r,
 
+  /etc/mime.types r,
+  /usr/share/applications/gnome-mimeapps.list r,
+
   owner @{PROC}/@{pid}/mountinfo r,
   owner @{PROC}/@{pid}/stat r,
   owner @{PROC}/@{pid}/status r,

--- a/apparmor/torbrowser.Browser.plugin-container
+++ b/apparmor/torbrowser.Browser.plugin-container
@@ -13,6 +13,8 @@ profile torbrowser_plugin_container {
   # owner @{PROC}/@{pid}/fd/ r,
   # owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/tmp/mozilla-temp-* rw,
 
+  signal (receive) set=("term") peer=torbrowser_firefox,
+
   deny /etc/host.conf r,
   deny /etc/hosts r,
   deny /etc/nsswitch.conf r,

--- a/apparmor/torbrowser.Browser.plugin-container
+++ b/apparmor/torbrowser.Browser.plugin-container
@@ -6,8 +6,10 @@ profile torbrowser_plugin_container {
 
   # Uncomment the following lines if you want Tor Browser
   # to have direct access to your sound hardware. You will also
-  # need to remove the "deny" word in the machine-id lines further
-  # bellow.
+  # need to remove, further bellow:
+  #  - the "deny" word in the machine-id lines
+  #  - the rules that deny reading /etc/pulse/client.conf
+  #    and executing /usr/bin/pulseaudio
   # #include <abstractions/audio>
   # /etc/asound.conf r,
   # owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/tmp/mozilla-temp-* rw,
@@ -84,6 +86,10 @@ profile torbrowser_plugin_container {
   deny @{PROC}/@{pid}/net/route r,
   deny /sys/devices/system/cpu/cpufreq/policy[0-9]*/cpuinfo_max_freq r,
   deny /sys/devices/system/cpu/*/cache/index[0-9]*/size r,
+
+  # Silence denial logs about PulseAudio
+  deny /etc/pulse/client.conf r,
+  deny /usr/bin/pulseaudio x,
 
   #include <local/torbrowser.Browser.plugin-container>
 }

--- a/apparmor/torbrowser.Browser.plugin-container
+++ b/apparmor/torbrowser.Browser.plugin-container
@@ -4,7 +4,7 @@
 profile torbrowser_plugin_container {
   #include <abstractions/gnome>
 
-  # Uncomment the following lines if you don'want the Tor Browser
+  # Uncomment the following lines if you want Tor Browser
   # to have direct access to your sound hardware. You will also
   # need to remove the "deny" word in the machine-id lines further
   # bellow.

--- a/apparmor/torbrowser.Browser.plugin-container
+++ b/apparmor/torbrowser.Browser.plugin-container
@@ -10,7 +10,6 @@ profile torbrowser_plugin_container {
   # bellow.
   # #include <abstractions/audio>
   # /etc/asound.conf r,
-  # owner @{PROC}/@{pid}/fd/ r,
   # owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/tmp/mozilla-temp-* rw,
 
   signal (receive) set=("term") peer=torbrowser_firefox,
@@ -29,6 +28,9 @@ profile torbrowser_plugin_container {
   /etc/mime.types r,
   /usr/share/applications/gnome-mimeapps.list r,
 
+  /dev/shm/ r,
+
+  owner @{PROC}/@{pid}/fd/ r,
   owner @{PROC}/@{pid}/mountinfo r,
   owner @{PROC}/@{pid}/stat r,
   owner @{PROC}/@{pid}/status r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-/home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Tor/tor {
+/home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor {
   #include <abstractions/base>
 
   network netlink raw,
@@ -11,19 +11,19 @@
   /etc/nsswitch.conf r,
   /etc/passwd r,
   /etc/resolv.conf r,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Tor/tor mr,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/ rw,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/* rw,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Tor/lock rwk,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/Tor,Lib}/*.so mr,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/Tor,Lib}/*.so.* mr,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor mr,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/ rw,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/* rw,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/lock rwk,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/*.so mr,
+  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/*.so.* mr,
 
   # Silence file_inherit logs
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}omni.ja r,
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}features/*.xpi r,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/.parentlock rw,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/extensions/*.xpi r,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/startupCache/* r,
+  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/.parentlock rw,
+  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/extensions/*.xpi r,
+  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/startupCache/* r,
 
   @{PROC}/sys/kernel/random/uuid r,
   /sys/devices/system/cpu/ r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -20,6 +20,7 @@
 
   # Silence file_inherit logs
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}omni.ja r,
+  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}features/*.xpi r,
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/.parentlock rw,
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/extensions/*.xpi r,
   deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/{Browser/TorBrowser/,}Data/Browser/profile.default/startupCache/* r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -1,4 +1,5 @@
 #include <tunables/global>
+#include <tunables/torbrowser>
 
 /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor {
   #include <abstractions/base>
@@ -11,19 +12,19 @@
   /etc/nsswitch.conf r,
   /etc/passwd r,
   /etc/resolv.conf r,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor mr,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/ rw,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/* rw,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Tor/lock rwk,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/*.so mr,
-  owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/*.so.* mr,
+  owner @{torbrowser_home_dir}/TorBrowser/Tor/tor mr,
+  owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/ rw,
+  owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/* rw,
+  owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/lock rwk,
+  owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so mr,
+  owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so.* mr,
 
   # Silence file_inherit logs
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}omni.ja r,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/{browser/,}features/*.xpi r,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/.parentlock rw,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/extensions/*.xpi r,
-  deny @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Data/Browser/profile.default/startupCache/* r,
+  deny @{torbrowser_home_dir}/{browser/,}omni.ja r,
+  deny @{torbrowser_home_dir}/{browser/,}features/*.xpi r,
+  deny @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/.parentlock rw,
+  deny @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/extensions/*.xpi r,
+  deny @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/startupCache/* r,
 
   @{PROC}/sys/kernel/random/uuid r,
   /sys/devices/system/cpu/ r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -16,10 +16,14 @@ profile torbrowser_tor @{torbrowser_tor_executable} {
   /etc/resolv.conf r,
   owner @{torbrowser_home_dir}/TorBrowser/Tor/tor mr,
   owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/ rw,
-  owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/* rw,
+  owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/** rw,
   owner @{torbrowser_home_dir}/TorBrowser/Data/Tor/lock rwk,
   owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so mr,
   owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so.* mr,
+
+  # Support some of the included pluggable transports
+  owner @{torbrowser_home_dir}/TorBrowser/Tor/PluggableTransports/** rix,
+  @{PROC}/sys/net/core/somaxconn r,
 
   # Silence file_inherit logs
   deny @{torbrowser_home_dir}/{browser/,}omni.ja r,

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -1,7 +1,9 @@
 #include <tunables/global>
 #include <tunables/torbrowser>
 
-/home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor {
+@{torbrowser_tor_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor
+
+profile torbrowser_tor @{torbrowser_tor_executable} {
   #include <abstractions/base>
 
   network netlink raw,


### PR DESCRIPTION
This branch includes:

* some follow-ups to #280 and #294 to make e10s work fine especially with a Linux 4.14 kernel
* silencing all the denial logs I could observe
* support for obfs4 and obfs3
* various updates, refactoring and clean-ups

Applying this upgrade to a running system requires special care, see the notes to packagers in the commit messages, that should IMO be copied to the release notes.