### PR TITLE
AppArmor: adjust Firefox binary path in rules for Tor Browser 8.0.

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -53,7 +53,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   owner @{torbrowser_home_dir}/.cache/fontconfig/** rwkl,
   owner @{torbrowser_home_dir}/components/*.so mr,
   owner @{torbrowser_home_dir}/browser/components/*.so mr,
-  owner @{torbrowser_home_dir}/firefox rix,
+  owner @{torbrowser_home_dir}/firefox.real rix,
   owner @{torbrowser_home_dir}/plugin-container px -> torbrowser_plugin_container,
   owner @{torbrowser_home_dir}/{,TorBrowser/UpdateInfo/}updates/[0-9]*/updater ix,
   owner @{torbrowser_home_dir}/{,TorBrowser/UpdateInfo/}updates/0/MozUpdater/bgupdate/updater ix,


### PR DESCRIPTION
Hello,

This patch is a follow-up of a67f026cc14c0a52decda0250890ee776a35f8a1.

In a67f026cc14c0a52decda0250890ee776a35f8a1, only
@{torbrowser_firefox_executable} was updated, but not the Firefox binary
path in the rules. This causes Tor Browser 8.0 to freeze. This patch should
fix it.
