### PR TITLE
Update README.md to use the newer apt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ If you want to always have the latest version of the `torbrowser-launcher` packa
 
 ```sh
 sudo add-apt-repository ppa:micahflee/ppa
-sudo apt-get update
-sudo apt-get install torbrowser-launcher
+sudo apt update
+sudo apt install torbrowser-launcher
 ```


### PR DESCRIPTION
5 years back Debian introduced apt as the new “pleasant for end users” tool over apt-get. The newer apt command works on all currently supported Ubuntu and Debian releases. See https://itsfoss.com/apt-vs-apt-get-difference/