### PR TITLE
Set language from LC_MESSAGES, not LC_CTYPE

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -100,7 +100,8 @@ class Common(object):
             "zh-CN",
             "zh-TW",
         ]
-        default_locale = locale.getlocale()[0]
+        locale.setlocale(locale.LC_MESSAGES, '')
+        default_locale = locale.getlocale(locale.LC_MESSAGES)[0]
         if default_locale is None:
             self.language = "en-US"
         else:


### PR DESCRIPTION
Calling `locale.getlocale()` checks LC_CTYPE, which is not meant for UI strings. Change the call to check LC_MESSAGES instead.

Also call `locale.setlocale()` first to import the locale settings from the environment. This is not needed for LC_CTYPE due to https://bugs.python.org/issue6203 but is required for LC_MESSAGES.

This Works For Me™, but I have only tested it on Gentoo Linux with the following locale settings:
```sh
LANG=
LC_CTYPE=sv_SE.utf8
LC_NUMERIC=sv_SE.utf8
LC_TIME=sv_SE.utf8
LC_COLLATE=POSIX
LC_MONETARY=sv_SE.utf8
LC_MESSAGES=POSIX
LC_PAPER=sv_SE.utf8
LC_NAME=sv_SE.utf8
LC_ADDRESS=sv_SE.utf8
LC_TELEPHONE=sv_SE.utf8
LC_MEASUREMENT=sv_SE.utf8
LC_IDENTIFICATION=sv_SE.utf8
LC_ALL=
```

Closes #361