### PR TITLE
[WIP] Open additional URLs with the same TorBrowser instance

### DIFF
--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -433,7 +433,9 @@ class Launcher(QtWidgets.QMainWindow):
             return
 
         # Run Tor Browser
-        subprocess.call([self.common.paths['tbb']['start']], cwd=self.common.paths['tbb']['dir_tbb'])
+        my_env = os.environ.copy()
+        my_env['LOGNAME'] = "torbrowserbundleuser"
+        subprocess.call([self.common.paths['tbb']['start'], '--allow-remote', self.url_list], cwd=self.common.paths['tbb']['dir_tbb'], env=my_env)
         sys.exit(0)
 
     # Start over and download TBB again


### PR DESCRIPTION
When we looked at the history of issues about opening links with TorBrowser, we
found #103 where initially the feature to open links from other applications
was added. Then some months later, the feature was removed again, as it was not
working because of #157 and #175. The issues was back then (~4years ago), that
when users had a normal Firefox running, urls got opened in the normal firefox
insead of TorBrowser. That was because TorBrowser had the --no-remote flag set
deep down in their code.
In the meanwhile TorBrowser removed the explicit --no-remote flag, so we are
able to use --allow-remote again.
On top of that there is another issue when we want open urls with TorBrowser:
If the LOGNAME is the same as the LOGNAME of the opened firefox, urls are still
opened in the open firefox. But if we set the LOGNAME envrionment variable
explicitly, we can make sure, that the url opens in the TorBrowser instead of
a running Firefox.

Should fix: #245, #259, #380 

WIP: it is not cleaned up, maybe we want revert 3f1146e1a084c4e8021da968104cbc2877ae01e6 and have the setting accept_links back.