### PR TITLE
Fixes #415 and #284

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -113,11 +113,7 @@ class Common(object):
             else:
                 arch = 'linux32'
 
-            if hasattr(self, 'settings') and self.settings['force_en-US']:
-                language = 'en-US'
-            else:
-                language = self.language
-            tarball_filename = 'tor-browser-' + arch + '-' + tbb_version + '_' + language + '.tar.xz'
+            tarball_filename = 'tor-browser-' + arch + '-' + tbb_version + '_' + self.language + '.tar.xz'
 
             # tarball
             self.paths['tarball_url'] = '{0}torbrowser/' + tbb_version + '/' + tarball_filename
@@ -300,6 +296,11 @@ class Common(object):
             if settings['tbl_version'] != self.tbl_version:
                 settings['tbl_version'] = self.tbl_version
                 resave = True
+            
+            # we need to update paths if force english is set
+            if settings['force_en-US']:
+                self.language = 'en-US'
+                self.build_paths()
 
             self.settings = settings
             if resave:


### PR DESCRIPTION
In your common class the methods build_paths() and load_settings() are very intertwined.
This results in the force_en-US setting to be ignored after extraction making it stuck on "Installing".
This approach reload the paths if this setting is found.
I'm not really happy with how the fix works but it does.

Hope it helps!

This should fix #415 and fix #284.