### PR TITLE
AppArmor updates for Tor Browser 9

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -105,6 +105,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
 
   # Required for multiprocess Firefox (aka Electrolysis, i.e. e10s)
   owner /{dev,run}/shm/org.chromium.* rw,
+  owner /dev/shm/org.mozilla.ipc.[0-9]*.[0-9]* rw, # for Chromium IPC
 
   # Deny access to DRM nodes, that's granted by the X abstraction, which is
   # sourced by the gnome abstraction, that we include.

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -73,7 +73,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so.* mr,
 
   # parent Firefox process when restarting after upgrade, Web Content processes
-  owner @{torbrowser_firefox_executable} ixmr -> torbrowser_firefox,
+  owner @{torbrowser_firefox_executable} pxmr -> torbrowser_firefox,
 
   /etc/mailcap r,
   /etc/mime.types r,


### PR DESCRIPTION
Hi!

Here's the diff we had to apply in Tails to make Tor Browser 9 work under AppArmor confinement.
I did not test this with a more standard Tor Browser 9 setup yet but the changes don't seem risky to me.

I'd love if someone could review this (and ideally, test it).

Tor Browser 9.0 will be released on October 22. It would be sweet if torbrowser-launcher had a release ready for it earlier so the transition is seemless for users :)