### PR TITLE
Allow torbrowser to access u2f devices

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -133,5 +133,14 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   /etc/xfce4/defaults.list r,
   /usr/share/xfce4/applications/ r,
 
+  # u2f (tested with Yubikey 4)
+  /sys/class/ r,
+  /sys/bus/ r,
+  /sys/class/hidraw/ r,
+  /run/udev/data/c24{7,9}:* r,
+  /dev/hidraw* rw,
+  # Yubikey NEO also needs this:
+  /sys/devices/**/hidraw/hidraw*/uevent r,
+
   #include <local/torbrowser.Browser.firefox>
 }


### PR DESCRIPTION
Start of discussion, see https://redmine.tails.boum.org/code/issues/17153

@intrigeri: I have tried to refine the rules a bit. And I realized that there might be differences between U2F devices, the (older) Yubikey NEO needs an additional permission. There might be additional rules needed for other U2F devices.