### PR TITLE
Update setup.py for python3.8 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,13 @@ import subprocess
 from distutils.core import setup
 
 SHARE = 'share'
-
-# detect linux distribution
-distro = platform.dist()[0]
+try:
+    #for distributions that use python3.8
+    import distro as d
+    distro=d.LinuxDistribution()._os_release_info['name']
+except:
+    # detect linux distribution on python >=3.7
+    distro = platform.dist()[0]
 
 
 def file_list(path):


### PR DESCRIPTION
modified to enable getting distro for python3.8 while maintaining ability to use python3.7 and below