### PR TITLE
Silence the deny apparmor log from lsb_release

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -122,6 +122,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   deny /sys/devices/system/cpu/cpufreq/policy[0-9]*/cpuinfo_max_freq r,
   deny /sys/devices/system/cpu/*/cache/index[0-9]*/size r,
   deny /run/user/[0-9]*/dconf/user rw,
+  deny /usr/bin/lsb_release x,
 
   # Silence denial logs about PulseAudio
   deny /etc/pulse/client.conf r,


### PR DESCRIPTION
This resolves debian bug: https://bugs.debian.org/913104

lsb_release is only used by Firefox to add extra information to crash reports,
and Tor Browser is built with --disable-crashreporter.

Therefore, AppArmor denying execution of lsb_release should be a no-op,
and we can silence the corresponding log message.