### PR TITLE
Remove use of deprecated platform.dist() (fixes #446)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,6 @@ from distutils.core import setup
 
 SHARE = "share"
 
-# detect linux distribution
-distro = platform.dist()[0]
-
 
 def file_list(path):
     files = []
@@ -72,24 +69,22 @@ for root, dirs, files in os.walk(SHARE):
     if files:
         datafiles.append((root, [os.path.join(root, f) for f in files]))
 
-# disable shipping apparmor profiles until they work in ubuntu (#128)
-if distro != "Ubuntu":
-    if not hasattr(sys, "real_prefix"):
-        # we're not in a virtualenv, so we can probably write to /etc
-        datafiles += [
-            (
-                "/etc/apparmor.d/",
-                ["apparmor/torbrowser.Browser.firefox", "apparmor/torbrowser.Tor.tor"],
-            ),
-            (
-                "/etc/apparmor.d/local/",
-                [
-                    "apparmor/local/torbrowser.Browser.firefox",
-                    "apparmor/local/torbrowser.Tor.tor",
-                ],
-            ),
-            ("/etc/apparmor.d/tunables/", ["apparmor/tunables/torbrowser"]),
-        ]
+if not hasattr(sys, "real_prefix"):
+    # we're not in a virtualenv, so we can probably write to /etc
+    datafiles += [
+        (
+            "/etc/apparmor.d/",
+            ["apparmor/torbrowser.Browser.firefox", "apparmor/torbrowser.Tor.tor"],
+        ),
+        (
+            "/etc/apparmor.d/local/",
+            [
+                "apparmor/local/torbrowser.Browser.firefox",
+                "apparmor/local/torbrowser.Tor.tor",
+            ],
+        ),
+        ("/etc/apparmor.d/tunables/", ["apparmor/tunables/torbrowser"]),
+    ]
 
 datafiles += [(os.path.dirname(f), [f]) for f in create_mo_files()]
 


### PR DESCRIPTION
platform.dist was deprecated a while ago and finally removed in Python 3.8. It was only used for a workaround for issue #128 (and #215) which is no longer necessary, so just remove the use altogether.

This broke the build for me with the Gentoo overlay, which upgraded to Python 3.8 recently.