### PR TITLE
Make torbrowser-launcher.mo ordering reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,9 @@ def create_mo_files():
         return []
     domain = "torbrowser-launcher"
     mo_files = []
-    po_files = [f for f in next(os.walk(po_dir))[2] if os.path.splitext(f)[1] == ".po"]
+    po_files = sorted(
+        [f for f in next(os.walk(po_dir))[2] if os.path.splitext(f)[1] == ".po"]
+    )
     for po_file in po_files:
         filename, extension = os.path.splitext(po_file)
         mo_file = domain + ".mo"


### PR DESCRIPTION
The ordering of `os.walk()` is [file system dependent](https://docs.python.org/3/library/os.html#os.listdir). To make sure that the generated `torbrowser-launcher.mo` is reproducible bit for bit no matter on which file system it was originally generated, sort the files before feeding them to `msgfmt`.