### PR TITLE
Use better version string comparison

### DIFF
--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -417,7 +417,10 @@ class Launcher(QtWidgets.QMainWindow):
                 installed_version = line.split()[2].decode()
                 break
 
-        if self.min_version <= installed_version:
+        def version_tuple(v):
+            return tuple(map(int, v.split(".")))
+
+        if version_tuple(self.min_version) <= version_tuple(installed_version):
             return True
 
         return False


### PR DESCRIPTION
Currently, this function compares raw version strings such as "7.5.2"
and "9.6" to find the newer version. This worked fine until Tor Browser
version 10 was released and "10.0" is no longer considered larger than
"7.5.2" by this function. This commit changes the function to split the
raw strings on periods and compares the corresponding tuples, such as
(7, 5, 2) and (10, 0). While this does not cover all edge cases, it
should work better for these purposes. It is also simple and avoids
adding an extra dependency compared to other options.

Fixes #498