### PR TITLE
Do not require the home directory to be writable

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -135,8 +135,6 @@ class Common(object):
                     self.set_gui(
                         "error", _("Error creating {0}").format(homedir), [], False
                     )
-        if not os.access(homedir, os.W_OK):
-            self.set_gui("error", _("{0} is not writable").format(homedir), [], False)
 
         tbb_config = '{0}/torbrowser'.format(self.get_env('XDG_CONFIG_HOME', '{0}/.config'.format(homedir)))
         tbb_cache = '{0}/torbrowser'.format(self.get_env('XDG_CACHE_HOME', '{0}/.cache'.format(homedir)))


### PR DESCRIPTION
Missing permissions can be handled later (once something needs to be written to the home directory). Is there some particular reason the permission is required?