### PR TITLE
Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,8 +12,8 @@ Then install dependencies, build a package, and install:
 ### Debian, Ubuntu, Linux Mint, etc.
 
 ```sh
-sudo apt install build-essential dh-python python3-all python3-stdeb python3-pyqt5 python3-gpg python3-requests python3-socks python3-packaging gnupg2 tor
-./build_deb.sh
+sudo apt install build-essential dh-python python3-all python3-stdeb python3-pyqt5 python3-gpg python3-requests python3-socks python3-packaging gnupg2 fakeroot tor
+sudo ./build_deb.sh
 sudo dpkg -i deb_dist/torbrowser-launcher_*.deb
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -21,7 +21,7 @@ sudo dpkg -i deb_dist/torbrowser-launcher_*.deb
 
 ```sh
 sudo dnf install rpm-build python3-qt5 python3-gpg python3-requests python3-pysocks python3-packaging gnupg2 tor
-./build_rpm.sh
+sudo ./build_rpm.sh
 sudo yum install dist/torbrowser-launcher-*.rpm
 ```
 


### PR DESCRIPTION
"./build.sh" and  "./build_rpm.sh" must be run as root; Missing essential "fakeroot" dependency in apt installation