### PR TITLE
platform.dist() is deprecated since Python3.5, replaced with distro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import os
 import sys
-import platform
+import distro
 import subprocess
 from distutils.core import setup
 
 SHARE = "share"
 
 # detect linux distribution
-distro = platform.dist()[0]
+distro = distro.linux_distribution()[0]
 
 
 def file_list(path):


### PR DESCRIPTION
Replace **platform** module with **distro** to avoid  **AttributeError: module 'platform' has no attribute 'dist'** issue since Python 3.8.

See here: https://docs.python.org/3.7/library/platform.html#unix-platforms