### PR TITLE
Fix pt_BR po file

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -145,7 +145,7 @@ msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
-"A versão do Navegador Tor que você instalou é anterior ao que deveria ser,
+"A versão do Navegador Tor que você instalou é anterior ao que deveria ser, "
 "o que poderia ser um sinal de ataque!"
 
 #: launcher.py:446


### PR DESCRIPTION
There are missing quotation marks at the end of line 148. This causes the build to fail:
```
po/pt_BR.po:149: end-of-line within string
msgfmt: found 1 fatal error

...

creating /app/share/locale/pt_BR
creating /app/share/locale/pt_BR/LC_MESSAGES
error: can't copy 'share/locale/pt_BR/LC_MESSAGES/torbrowser-launcher.mo': doesn't exist or not a regular file
```

This PR fixes the issue (verified with _msgfmt_). @micahflee Please, merge this PR and do a new tag with this issue fixed. Thanks!