### PR TITLE
Add install_requires, use it in tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt-get install gettext python3 python3-packaging python3-gpg python3-pyqt5 python3-requests python3-socks
+    - name: Install system dependencies
+      run: sudo apt-get install gettext python3
+    - name: Install python dependencies
+      run: sudo pip3 install .
     - name: Build torbrowser-launcher
       run: python3 setup.py build
     - name: Install torbrowser-launcher

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,3 +19,5 @@ jobs:
       run: python3 setup.py build
     - name: Install torbrowser-launcher
       run: sudo python3 setup.py install
+    - name: Test torbrowser-launcher install
+      run: torbrowser-launcher -h

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install system dependencies
-      run: sudo apt-get install gettext python3
+      run: sudo apt-get install gettext python3 libgpgme-dev
     - name: Install python dependencies
       run: sudo pip3 install .
     - name: Build torbrowser-launcher

--- a/setup.py
+++ b/setup.py
@@ -118,4 +118,11 @@ Browser.
     packages=["torbrowser_launcher"],
     scripts=["torbrowser-launcher"],
     data_files=datafiles,
+    install_requires=[
+        'gpg',
+        'packaging',
+        'PyQt5',
+        'requests',
+        'PySocks',
+    ],
 )


### PR DESCRIPTION
I got some feedback from @eli-schwartz on #583 and addressed them in this PR:

- Define the dependencies in `setup.py`
- In github actions, read the dependencies from that file
- Ensure everything actually works in the end by running `torbrowser-launcher -h`