### PR TITLE
Rebuild paths in case force_en-US was set

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,11 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install system dependencies
       run: sudo apt-get install gettext python3 libgpgme-dev
-    - name: Install python dependencies
-      run: sudo pip3 install .
-    - name: Build torbrowser-launcher
-      run: python3 setup.py build
     - name: Install torbrowser-launcher
-      run: sudo python3 setup.py install
+      run: sudo pip3 install .
     - name: Test torbrowser-launcher install
       run: torbrowser-launcher -h

--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -63,6 +63,8 @@ class Common(object):
             self.mkdir(self.paths["dirs"][d])
         self.load_mirrors()
         self.load_settings()
+        # some settings require a path rebuild, like force_en-US
+        self.build_paths()
         self.mkdir(self.paths["download_dir"])
         self.mkdir(self.paths["tbb"]["dir"])
         self.init_gnupg()
@@ -167,6 +169,11 @@ class Common(object):
         )
         old_tbb_data = "{0}/.torbrowser".format(homedir)
 
+        if hasattr(self, "settings") and self.settings["force_en-US"]:
+            language = "en-US"
+        else:
+            language = self.language
+
         if tbb_version:
             # tarball filename
             if self.architecture == "x86_64":
@@ -174,10 +181,6 @@ class Common(object):
             else:
                 arch = "linux32"
 
-            if hasattr(self, "settings") and self.settings["force_en-US"]:
-                language = "en-US"
-            else:
-                language = self.language
             tarball_filename = (
                 "tor-browser-" + arch + "-" + tbb_version + "_" + language + ".tar.xz"
             )
@@ -230,19 +233,19 @@ class Common(object):
                     + "/tbb/"
                     + self.architecture
                     + "/tor-browser_"
-                    + self.language
+                    + language
                     + "/Browser/TorBrowser/Docs/ChangeLog.txt",
                     "dir": tbb_local + "/tbb/" + self.architecture,
                     "dir_tbb": tbb_local
                     + "/tbb/"
                     + self.architecture
                     + "/tor-browser_"
-                    + self.language,
+                    + language,
                     "start": tbb_local
                     + "/tbb/"
                     + self.architecture
                     + "/tor-browser_"
-                    + self.language
+                    + language
                     + "/start-tor-browser.desktop",
                 },
             }


### PR DESCRIPTION
This upstreams a patch from debian (added a comment to make it slightly easier to understand why `build_paths` is run twice): https://sources.debian.org/patches/torbrowser-launcher/0.3.3-6/05-Fix-use-case-that-enforce-install-of-EN-version-on-n.patch/

This fixes https://bugs.archlinux.org/task/67823 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=842021

Closes #415
Closes #284