### PR TITLE
Fix U2F for Yubikey 5 tokens

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -146,7 +146,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   /sys/class/ r,
   /sys/bus/ r,
   /sys/class/hidraw/ r,
-  /run/udev/data/c24{7,9}:* r,
+  /run/udev/data/c24{5,7,9}:* r,
   /dev/hidraw* rw,
   # Yubikey NEO also needs this:
   /sys/devices/**/hidraw/hidraw*/uevent r,


### PR DESCRIPTION
This change avoids AppArmor blocking access to the Yubikey 5 hardware token for 2FA functionality in the Tor browser.