### PR TITLE
Launch fails with Python 3.10, Fix strict parameters for gui.move

### DIFF
--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -90,8 +90,8 @@ def main():
     desktop = app.desktop()
     window_size = gui.size()
     gui.move(
-        (desktop.width() - window_size.width()) / 2,
-        (desktop.height() - window_size.height()) / 2,
+        int((desktop.width() - window_size.width()) / 2),
+        int((desktop.height() - window_size.height()) / 2),
     )
     gui.show()
 


### PR DESCRIPTION
```
Tor Browser Launcher
By Micah Lee, licensed under MIT
version 0.3.5
https://github.com/micahflee/torbrowser-launcher
Downloading Tor Browser for the first time.
Downloading https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US
Traceback (most recent call last):
  File "/usr/bin/torbrowser-launcher", line 30, in <module>
    torbrowser_launcher.main()
  File "/usr/lib/python3.10/site-packages/torbrowser_launcher/__init__.py", line 92, in main
    gui.move(
TypeError: arguments did not match any overloaded call:
  move(self, QPoint): argument 1 has unexpected type 'float'
  move(self, int, int): argument 1 has unexpected type 'float'

```

Adding int() wrappers around the parameters in question fixed it.