### PR TITLE
Pass correct data type to gui.move()

### DIFF
--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -90,8 +90,8 @@ def main():
     desktop = app.desktop()
     window_size = gui.size()
     gui.move(
-        (desktop.width() - window_size.width()) / 2,
-        (desktop.height() - window_size.height()) / 2,
+        (desktop.width() - window_size.width()) // 2,
+        (desktop.height() - window_size.height()) // 2,
     )
     gui.show()
 


### PR DESCRIPTION
move() function prototype expects two ints rather than floats.