### PR TITLE
QtWidget.move arguments are expected to be integers

### DIFF
--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -90,8 +90,8 @@ def main():
     desktop = app.desktop()
     window_size = gui.size()
     gui.move(
-        (desktop.width() - window_size.width()) / 2,
-        (desktop.height() - window_size.height()) / 2,
+        int((desktop.width() - window_size.width()) / 2),
+        int((desktop.height() - window_size.height()) / 2),
     )
     gui.show()
 


### PR DESCRIPTION
On first startup I get this error:

```
Downloading Tor Browser for the first time.                                                               
Downloading https://aus1.torproject.org/torbrowser/update_3/release/Linux_x86_64-gcc3/x/en-US                                                                                                                        
Traceback (most recent call last):                   
  File "/usr/bin/torbrowser-launcher", line 30, in <module>                                               
    torbrowser_launcher.main()                                                                            
  File "/usr/lib/python3/dist-packages/torbrowser_launcher/__init__.py", line 98, in main                 
    gui.move(                                        
TypeError: arguments did not match any overloaded call:                                                   
  move(self, QPoint): argument 1 has unexpected type 'float'                                              
  move(self, int, int): argument 1 has unexpected type 'float' 
```

According to the QWidget interface [here](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QWidget.html#PySide2.QtWidgets.PySide2.QtWidgets.QWidget.move) the move arguments are expected to be integers.