### PR TITLE
Fix python strict type checking in Python 3.9+ (#628)

### DIFF
--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -90,8 +90,8 @@ def main():
     desktop = app.desktop()
     window_size = gui.size()
     gui.move(
-        (desktop.width() - window_size.width()) / 2,
-        (desktop.height() - window_size.height()) / 2,
+        (desktop.width() - window_size.width()) // 2,
+        (desktop.height() - window_size.height()) // 2,
     )
     gui.show()
 


### PR DESCRIPTION
Python 3.9+ started doing strict enforcement of types.  This results in the GUI function methods not functioning properly in modern Python environments.

Fixes #628

Thanks to @icceland in bug 628 for the fix stated in the bug, credit goes to them, they asked in that bug if someone else can put the merge in and give them credit.