### PR TITLE
Fix/locale folders crash

### DIFF
--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2019-10-26 19:51+0300\n"
 "Last-Translator: Viktar Siarheichyk <vics@eq.by>\n"
 "Language-Team: Belarusian <debian-l10n-belarusian@lists.debian.org>\n"
@@ -16,127 +16,128 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Запускальнік Tor Browser"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Аўтар Micah Lee, ліцэнзія MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "версія {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Памылка падчас стварэння {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} не можа быць запісаны"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Не ўдалася стварыць каталог {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Ствараем хатні каталог GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Не ўдалося імпартаваць ключ з адбіткам: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Не ўсе ключы імпартаваны паспяхова!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Атрыманне Tor Browser упершыню."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Ваша версія Tor Browser пратэрмінавана. Атрымліваем найноўшую версію."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Згружаем праз Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Запуск"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Так"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Выйсці"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Адмяніць"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Згружаецца"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Апошняя версія: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Памылка падчас вызначэння версіі Tor Browser."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Правяраецца подпіс"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Распакоўваецца"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Працуе"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Запускаем загрузку наноў"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(праз Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Згружана"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Усталяванне"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Запускальнік Tor Browser не разумее фармат файла {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -144,19 +145,20 @@ msgstr ""
 "Гэта версія Tor Browser, якую вы паставілі, ёсць ранейшай, чым мае быць, што "
 "можа паказваць на атаку!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Атрыманне Tor Browser ізноў."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Памылка загрузкі:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Зараз вы карыстаецеся не стандартным люстэркам"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Змяніць на стандартнае?"
 
@@ -164,7 +166,7 @@ msgstr "Змяніць на стандартнае?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Паспрабаваць узамен ангельскую версію Tor Browser?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -177,11 +179,11 @@ msgstr ""
 "\n"
 "Магчыма, вас атакуюць."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Зноў паспрабаваць згрузіць праз Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -198,7 +200,7 @@ msgstr ""
 "Спрабуем згрузіць праз Tor. Перакананыя, што Tor карэктна сканфігураваны і "
 "працуе?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -213,11 +215,11 @@ msgstr ""
 "\n"
 "Вы далучаны да інтэрнэта?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Налады запускальніка Tor Browser"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Згрузіць праз сістэмны Tor"
 
@@ -225,30 +227,50 @@ msgstr "Згрузіць праз сістэмны Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Прымусова згрузіць ангельскую версію Tor Browser"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Сервер Tor"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Стан: усталяваны"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Стан: не ўсталяваны"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Усталяваць Tor Browser"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Пераставіць Tor Browser"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Люстэрка"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Захаваць && выйсці"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2021-06-20 19:42+0200\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: \n"
@@ -18,127 +18,128 @@ msgstr ""
 "X-Generator: Poedit 2.4.3\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Spouštěč prohlížeče Tor"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Vytvořil Micah Lee pod licencí MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "verze {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Chyba při vytváření {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "Do {0} není možné zapisovat"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Nelze vytvořit adresář {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Vytváří se domovská složka GnuGPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Selhal import klíče s otiskem: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Ne všechny klíče byly importovány úspěšně!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Poprvé se stahuje Prohlížeč Tor."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Vaše verze Prohlížeče Tor je zastaralá. Stahuje se nejnovější verze."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Stahování přes Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Prohlížeč Tor"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Spustit"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Ano"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Ukončit"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Zrušit"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Stahuje se"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Nejnovější verze: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Chyba při zjišťování verze Prohlížeče Tor."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Ověřuje se podpis"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Extrahuje se"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Běží"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Stahování se spouští znovu"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(přes Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Staženo"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Instaluje se"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Spouštěč prohlížeče Tor nerozumí formátu souboru {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -146,19 +147,20 @@ msgstr ""
 "Verze prohlížeče Tor, kterou máte nainstalovanou, je ranější, než by měla "
 "být, což může značit útok!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Znovu se stahuje Prohlížeč Tor."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Chyba stahování:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Používáte právě nevýchozí zrcadlo"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Přejete si přepnout zpět na výchozí?"
 
@@ -166,7 +168,7 @@ msgstr "Přejete si přepnout zpět na výchozí?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Přejete si místo toho zkusit anglickou verzi Prohlížeče Tor?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -179,11 +181,11 @@ msgstr ""
 "\n"
 "Můžete být pod útokem."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Zkusit stahování znovu pomocí Toru?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -200,7 +202,7 @@ msgstr ""
 "Zkouší se stahování přes Tor. Jste si jistí, že Tor běží a je správně "
 "nastaven?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -215,11 +217,11 @@ msgstr ""
 "\n"
 "Jste připojeni k internetu?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Nastavení Spouštěče prohlížeče Tor"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Stáhnout přes systémový Tor"
 
@@ -227,33 +229,53 @@ msgstr "Stáhnout přes systémový Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Vynutit stažení anglické verze Prohlížeče Tor"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Server Toru"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Stav: Nainstalováno"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Stav: Nenainstalováno"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Nainstalovat Prohlížeč Tor"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Přeinstalovat Prohlížeč Tor"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Zrcadlo"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Uložit a ukončit"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"

--- a/po/da.po
+++ b/po/da.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: torbrowser-launcher\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2018-09-30 16:24+0200\n"
 "Last-Translator: scootergrisen\n"
 "Language-Team: Danish\n"
@@ -16,127 +16,128 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser-opstarter"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Af Micah Lee, licenseret under MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "version {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Fejl ved oprettelse af {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} er skrivebeskyttet"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Kan ikke oprette mappen {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Opretter GnuPG-hjemmemappe"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Kunne ikke importere nøgle med fingeraftryk: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Det lykkedes ikke at importere alle nøgler!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Downloader Tor Browser for første gang."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Din version af Tor Browser er forældet. Downloader den nyeste version."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Downloader over Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Start"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Ja"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Afslut"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Annuller"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Downloader"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Seneste version: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Fejl ved registrering af Tor Browser-version."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Verificerer signatur"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Udpakker"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Kører"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Starter download på ny"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(over Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Downloadet"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Installerer"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor Browser-opstarter forstår ikke filformatet af {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -144,19 +145,20 @@ msgstr ""
 "Den version af Tor Browser som du har installeret er tidligere end den bør "
 "være, hvilket kan være tegn på angreb!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Downloader Tor Browser på ny."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Fejl ved download:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Du bruger i øjeblikket et spejl som ikke er standard"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Vil du skifte tilbage til standarden?"
 
@@ -164,7 +166,7 @@ msgstr "Vil du skifte tilbage til standarden?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Vil du i stedet prøve den engelske version af Tor Browser?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -177,11 +179,11 @@ msgstr ""
 "\n"
 "Du er måske under angreb."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Prøv downloaden igen med Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -198,7 +200,7 @@ msgstr ""
 "Prøver at downloade over Tor. Er du sikker på, at Tor er konfigureret "
 "korrekt og kører?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -213,11 +215,11 @@ msgstr ""
 "\n"
 "Har du forbindelse til internettet?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Indstillinger for Tor Browser-opstarter"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Download over systemets Tor"
 
@@ -225,30 +227,50 @@ msgstr "Download over systemets Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Tving download af den engelske version af Tor Browser"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor-server"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Status: Installeret"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Status: Ikke installeret"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Installer Tor Browser"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Geninstaller Tor Browser"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Spejl"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Gem og afslut"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2019-12-15 21:28+0100\n"
 "Last-Translator: René Mario Baumgartner <ned84@protonmail.com>\n"
 "Language-Team: \n"
@@ -14,129 +14,130 @@ msgstr ""
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser Launcher"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Von Micah Lee, lizensiert unter MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "Version {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Fehler erzeugt {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} ist nicht schreibbar"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Kann Verzeichnis {0} nicht erzeugen"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Erzeuge GnuPG Verzeichnis"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Konnte Schlüssel mit folgendem Fingerabdruck nicht importieren: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Nicht alle Schlüssel konnten erfolgreich importiert werden!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Lade Tor Browser das erste mal herunter."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 "Ihre Version des Tor Browsers ist nicht mehr aktuell. Lade die neueste "
 "Version herunter."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Lade über Tor herunter"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Start"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Ja"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Exit"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Abbruch"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Herunterladen"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Aktuelle Version: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Fehler bei dem Versuch die Tor Browser Version zu finden."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Prüfe Signatur"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Extrahieren"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Läuft"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Starte download nochmals"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(über Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Installiere"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor Browser versteht folgendes Datei Format nicht: {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -144,19 +145,20 @@ msgstr ""
 "Die Version ihres Tor Browsers ist neuer als sie sein sollte, was auf eine "
 "Attacke schließen lassen könnte!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Lade Tor Browser nochmals herunter."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Fehler beim herunterladen:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Sie verwenden zur Zeit einen nicht voreingestellten Mirror."
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Wollen sie zur Voreinstellung wechseln?"
 
@@ -165,7 +167,7 @@ msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr ""
 "Wollen sie die englische Version des Tor Browsers stattdessen versuchen?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -178,11 +180,11 @@ msgstr ""
 "\n"
 "Möglicherweise werden sie angegriffen."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Wollen sie das herunterladen nochmals über Tor versuchen?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -199,7 +201,7 @@ msgstr ""
 "Versuche über Tor herunterzuladen. Sind sie sicher das Tor richtig "
 "konfiguriert und aktiv ist?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -214,11 +216,11 @@ msgstr ""
 "\n"
 "Sind sie mit dem Internet verbunden?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Tor Browser Launcher Einstellungen"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Herunterladen über system Tor"
 
@@ -226,30 +228,50 @@ msgstr "Herunterladen über system Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Herunterladen der englischen Version des Tor Browsers erzwingen"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor server"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Status: Installiert"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Status: Nicht installiert"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Tor Browser installieren"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Tor Browser nochmals installieren"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Mirror"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Speichern && Exit"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2016-12-02 15:16+0400\n"
 "Last-Translator: Andrey Kunitsyn <contact@libnaru.so>\n"
 "Language-Team: French\n"
@@ -18,129 +18,130 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser Launcher"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Par Micah Lee, sous licence MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "version {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Erreur lors de la création de {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "Impossible d'écrire {0}"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Impossible de créer le dossier {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Création du dossier GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Impossible d'importer la clé avec l'empreinte : %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Certaines clés n'ont pas pu être importées !"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Téléchargement du Navigateur Tor pour la première fois."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 "Votre version du Navigateur Tor est obsolète. Téléchargement de la nouvelle "
 "version."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Télécharger à travers Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Navigateur Tor"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Démarrer"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Oui"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Quitter"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Annuler"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Téléchargement"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Dernière version : {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Impossible de détecter la version du Navigateur Tor."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Vérification de la signature"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Décompression"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Exécution"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Télécharger à nouveau"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(à travers Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Téléchargé"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Installation en cours"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor Browser Launcher ne comprend pas le format du fichier {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -148,19 +149,20 @@ msgstr ""
 "La version du Navigateur Tor que vous avez installé est antérieure à ce "
 "qu'elle devrait, ce qui peut être le signe d'une attaque !"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Télécharger le Navigateur Tor à nouveau."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Erreur de téléchargement :"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Vous utilisez actuellement un miroir n'étant pas celui par défaut"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Voulez-vous revenir à la valeur par défaut ?"
 
@@ -169,7 +171,7 @@ msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr ""
 "Voulez-vous essayer la version anglophone du Navigateur Tor à la place ?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -182,11 +184,11 @@ msgstr ""
 "\n"
 "Vous pourriez être attaqué."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Essayer de télécharger à nouveau à travers Tor ?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -203,7 +205,7 @@ msgstr ""
 "Essayez de télécharger à travers Tor. Êtes-vous sûr que Tor est configuré "
 "correctement et fonctionne ?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -218,11 +220,11 @@ msgstr ""
 "\n"
 "Êtes-vous connecté à Internet ?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Configuration du Tor Browser Launcher"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Télécharger à travers le Tor installé sur le système"
 
@@ -230,33 +232,53 @@ msgstr "Télécharger à travers le Tor installé sur le système"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Forcer le téléchargement de la version anglophone du Navigateur Tor"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Serveur Tor"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Statut : Installé"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Statut : Pas installé"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Installer le Navigateur Tor"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Réinstaller le Navigateur Tor"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Miroir"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Enregistrer et quitter"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"

--- a/po/hr.po
+++ b/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Tor Browser Launcher\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2020-01-22 13:20+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
@@ -16,131 +16,132 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.12\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Pokretač Tor preglednika"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Autor Micah Lee, MIT licenca"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "verzija {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Greška prilikom stvaranja {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "Nije moguće pisati u {0}"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Nije moguće stvoriti mapu {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Izrada početne mape za GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Nije bilo moguće uvesti ključ s otiskom prsta: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Nisu svi ključevi uspješno uvezeni!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Preuzimanje Tor preglednika po prvi put."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 "Tvoja verzija Tor preglednika je zastarjela. Preuzima se najnovija verzija."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Preuzimanje preko Tora"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor preglednik"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Pokreni"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Da"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Zatvori"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Odustani"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Preuzimanje"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Zadnja verzija: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Greška prilikom otkrivanja verzije Tor preglednika."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Potvrđivanje potpisa"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Otpakiravanje"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Izvršava se"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Pokreće se ponovno preuzimanje"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(preko Tora)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Preuzeto"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Instaliranje"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Pokretač Tor preglednika ne razumije format datoteke {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -148,19 +149,20 @@ msgstr ""
 "Tvoja verzija Tor preglednika je starija nego što bi trebala biti, što može "
 "biti znak napada!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Ponovno preuzimanje Tor preglednika."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Greška prilikom preuzimanja:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Trenutačno koristiš nestandardno zrcalo"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Želiš li vratiti na standardno?"
 
@@ -168,7 +170,7 @@ msgstr "Želiš li vratiti na standardno?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Želiš li umjesto toga isprobati englesku verziju Tor preglednika?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -181,11 +183,11 @@ msgstr ""
 "\n"
 "Možda si napadnut/a."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Ponovo pokušati preuzeti pomoću Tora?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -202,7 +204,7 @@ msgstr ""
 "Pokušava se preuzeti preko Tora. Je li je Tor ispravno konfiguriran i "
 "pokrenut?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -217,11 +219,11 @@ msgstr ""
 "\n"
 "Jesi li spojen/a na internet?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Postavke pokretača Tor preglednika"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Preuzmi preko Tora sustava"
 
@@ -229,30 +231,50 @@ msgstr "Preuzmi preko Tora sustava"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Prisili preuzimanje engleske verzije Tor preglednika"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor poslužitelj"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Stanje: Instalirano"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Stanje: Nije instalirano"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Instaliraj Tor preglednik"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Ponovo instaliraj Tor preglednik"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Zrcalo"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Spremi i zatvori"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2017-02-16 00:55+0100\n"
 "Last-Translator: Barcza Károly <kbarcza@blackpanther.hu>\n"
 "Language-Team: \n"
@@ -18,53 +18,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor böngésző indító"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Micah Lee által MIT licenc alatt"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "verzió {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Hiba a(z) {0} létrehozásakor"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} nem írható"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Nem sikerült a(z) {0} létrehozása"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "GnuPG könyvtár létrehozása"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Nem lehetett importálni a kulcsot ujjlenyomattal: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr ""
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 #, fuzzy
 msgid "Downloading Tor Browser for the first time."
 msgstr "Tor böngésző letöltése és telepítése első alkalommal."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 #, fuzzy
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
@@ -72,77 +72,78 @@ msgstr ""
 "A Tor böngésző verziója elavult. Töltsük le és telepítsük a legfrissebb "
 "változatot."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Letöltés Tor-on keresztül"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor böngésző"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Elindítás"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr ""
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr ""
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Megszakít"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Letöltés"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Legújabb változat: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Hiba a Tor böngésző verzió felsimerésekor"
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Aláírás ellenőrzése"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Kibontás"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Fut"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Újra letöltés indítása"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr ""
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Letöltve"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Telepítés.."
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor böngésző indító nem érti a(z) {0} fájl formátumot."
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -150,20 +151,21 @@ msgstr ""
 "A Tor böngésződ verziója egy korábbi verzió mint amilyennek lennie kellene, "
 "ami lehet egy támadás jele!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 #, fuzzy
 msgid "Downloading Tor Browser over again."
 msgstr "Tör böngészőcsomag letöltése újra."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Hiba a letöltésben:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Jelenleg használt tükörszerver nem az alapértelmezett"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Valóban szeretnéd visszaváltani alapértelmezettre?"
 
@@ -171,7 +173,7 @@ msgstr "Valóban szeretnéd visszaváltani alapértelmezettre?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Ehelyett megpróbálod a Tor böngésző angol változatát ?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -180,11 +182,11 @@ msgid ""
 "You may be under attack."
 msgstr ""
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Megpróbálod újra a Tor letöltését?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -195,7 +197,7 @@ msgid ""
 "running?"
 msgstr ""
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -210,11 +212,11 @@ msgstr ""
 "\n"
 "Csatlakozva vagy az internethez?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Tör böngésző indító beállítások"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Letöltés rendszer Tor-on keresztül"
 
@@ -222,34 +224,54 @@ msgstr "Letöltés rendszer Tor-on keresztül"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Kényszerítse a Tor angol változatának letöltését"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor-szerver"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Állapot: Telepített"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Állapot: Nincs telepítve"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Tor-böngésző telepítése"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Tor böngésző úratelepítése"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Tükrözés"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 #, fuzzy
 msgid "Save && Exit"
 msgstr "Mentés és kilépés"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2016-12-02 17:40+0400\n"
 "Last-Translator: Andrey Kunitsyn <contact@libnaru.so>\n"
 "Language-Team: \n"
@@ -18,148 +18,150 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser Launcher"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Door Micah Lee, onder MIT licensie"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "versie {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Fout bij maken van {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} is niet schrijfbaar"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Kan map niet maken: {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Aanmeken GnuPG map"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr ""
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr ""
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 #, fuzzy
 msgid "Downloading Tor Browser for the first time."
 msgstr "Tor Browser Bundle opnieuw aan het downloaden."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr ""
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Start"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr ""
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr ""
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Annuleren"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Bezig met downloaden"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 #, fuzzy
 msgid "Latest version: {}"
 msgstr "Laatste versie: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr ""
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Handtekening verifiëren"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Uitpakken"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Uitvoeren"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr ""
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr ""
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Gedownload"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Installeren"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr ""
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 #, fuzzy
 msgid "Downloading Tor Browser over again."
 msgstr "Tor Browser Bundle opnieuw aan het downloaden."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Download fout:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr ""
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr ""
 
@@ -167,7 +169,7 @@ msgstr ""
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr ""
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -176,11 +178,11 @@ msgid ""
 "You may be under attack."
 msgstr ""
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Probeer de download opnieuw via Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -191,7 +193,7 @@ msgid ""
 "running?"
 msgstr ""
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -206,11 +208,11 @@ msgstr ""
 "\n"
 "Bent u verbonden met het internet?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Tor Browser Launcher Instellingen"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr ""
 
@@ -218,34 +220,54 @@ msgstr ""
 msgid "Force downloading English version of Tor Browser"
 msgstr ""
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr ""
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr ""
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr ""
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr ""
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr ""
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr ""
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 #, fuzzy
 msgid "Save && Exit"
 msgstr "Opslaan & afsluiten"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The SSL certificate served by https://www.torproject.org is invalid! You "

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2016-12-02 15:35+0400\n"
 "Last-Translator: AreYouLoco? <areyouloco@paranoici.org>\n"
 "Language-Team: Polish\n"
@@ -19,147 +19,149 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Launcher Przeglądarki Tora"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr ""
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "wersja {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Błąd przy tworzeniu {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} jest tylko do odczytu"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Nie można stworzyć {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Tworzenie katalogu głównego GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr ""
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr ""
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 #, fuzzy
 msgid "Downloading Tor Browser for the first time."
 msgstr "Ponowne pobieranie Tor Browser Bundle"
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr ""
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Przeglądarka Tora"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr ""
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr ""
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr ""
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr ""
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Pobieranie"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr ""
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr ""
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Weryfikowanie podpisu"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Rozpakowywanie"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Uruchamianie"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Ponowne rozpoczynanie pobierania"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr ""
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Pobrano"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Instalowanie"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr ""
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 #, fuzzy
 msgid "Downloading Tor Browser over again."
 msgstr "Ponowne pobieranie Tor Browser Bundle"
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Błąd pobierania:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr ""
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr ""
 
@@ -167,7 +169,7 @@ msgstr ""
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr ""
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -176,11 +178,11 @@ msgid ""
 "You may be under attack."
 msgstr ""
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr ""
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -191,7 +193,7 @@ msgid ""
 "running?"
 msgstr ""
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -206,11 +208,11 @@ msgstr ""
 "\n"
 "Czy jesteś podłąćzony do internetu?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr ""
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr ""
 
@@ -218,32 +220,52 @@ msgstr ""
 msgid "Force downloading English version of Tor Browser"
 msgstr ""
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr ""
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr ""
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr ""
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr ""
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr ""
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr ""
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
+msgstr ""
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
 msgstr ""
 
 #~ msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2020-02-09 16:35-0300\n"
-"Language: pt_BR\n"
-"Language-Team: \n"
 "Last-Translator: João Vítor S. F. <jjoaovitor7@outlook.com.br>\n"
+"Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,149 +19,154 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Lançador do Navegador Tor"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Por Micah Lee, licenciado sob o MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "versão {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Erro ao criar {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} não é gravável"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Não é possível criar o diretório {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Criando o diretório inicial do GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Não foi possível importar a chave com a impressão digital: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Nem todas as chaves foram importadas com sucesso!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 #, fuzzy
 msgid "Downloading Tor Browser for the first time."
 msgstr "Baixando o Navegador Tor pela primeira vez."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 #, fuzzy
-msgid "Your version of Tor Browser is out-of-date. Downloading the newest version."
-msgstr "Sua versão do Navegador Tor está desatualizada. Baixando a versão mais recente."
+msgid ""
+"Your version of Tor Browser is out-of-date. Downloading the newest version."
+msgstr ""
+"Sua versão do Navegador Tor está desatualizada. Baixando a versão mais "
+"recente."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Baixando pelo Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Navegador Tor"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Iniciar"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Sim"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Sair"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Baixando"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Versão mais recente: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Erro ao detectar a versão do Navegador Tor."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Verificando Assinatura"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Extraindo"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Rodando"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Iniciando o download novamente"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(pelo Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Baixado"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Instalando"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "O Lançador do Navegador Tor não entende o formato do arquivo de {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
-"A versão do Navegador Tor que você instalou é anterior ao que deveria ser, "
-"o que poderia ser um sinal de ataque!"
+"A versão do Navegador Tor que você instalou é anterior ao que deveria ser, o "
+"que poderia ser um sinal de ataque!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 #, fuzzy
 msgid "Downloading Tor Browser over again."
 msgstr "Baixando o Navegador Tor novamente.."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Erro de Download:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "No momento você está usando espelho não-padrão"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Você gostaria de retornar para o padrão?"
 
@@ -169,7 +174,7 @@ msgstr "Você gostaria de retornar para o padrão?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Você gostaria de experimentar a versão em inglês do Navegador Tor?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -182,11 +187,11 @@ msgstr ""
 "\n"
 "Você pode estar sob ataque."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Tentar o download novamente usando o Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -200,10 +205,10 @@ msgstr ""
 "\n"
 "{0}\n"
 "\n"
-"Tentando fazer o download pelo Tor. Você tem certeza de que o Tor está configurado corretamente e "
-"e funcionando?"
+"Tentando fazer o download pelo Tor. Você tem certeza de que o Tor está "
+"configurado corretamente e e funcionando?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -218,11 +223,11 @@ msgstr ""
 "\n"
 "Você está conectado à internet?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Configurações do Lançador do Navegador Tor"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Download pelo sistema Tor"
 
@@ -230,39 +235,60 @@ msgstr "Download pelo sistema Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Forçar o download da versão em Inglês do Navegador Tor"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Servidor Tor"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Estado: Instalado"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Estado: Não Instalado"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Instalar o Navegador Tor"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Reinstalar o Navegador Tor"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Espelho"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 #, fuzzy
 msgid "Save && Exit"
 msgstr "Salvar && Sair"
 
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
+
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"
-#~ msgstr
-#~ "O pacote python-txsocksx está faltando, os downloads não acontecerão pelo tor"
+#~ msgstr ""
+#~ "O pacote python-txsocksx está faltando, os downloads não acontecerão pelo "
+#~ "tor"
 
 #~ msgid "DNS Lookup Error"
 #~ msgstr "Erro de Pesquisa de DNS"
@@ -271,8 +297,8 @@ msgstr "Salvar && Sair"
 #~ "The SSL certificate served by https://www.torproject.org is invalid! You "
 #~ "may be under attack."
 #~ msgstr ""
-#~ "O certificado SSL fornecido por https://www.torproject.org é inválido! Você "
-#~ "pode estar sob ataque."
+#~ "O certificado SSL fornecido por https://www.torproject.org é inválido! "
+#~ "Você pode estar sob ataque."
 
 #~ msgid "Error connecting to Tor at {0}"
 #~ msgstr "Erro ao conectar ao Tor em {0}"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2018-07-07 19:50+0400\n"
 "Last-Translator: Andrey Kunitsyn Sergeevich <contact@libnaru.so>\n"
 "Language-Team: Russian\n"
@@ -19,127 +19,128 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n % 10==1 && n % 100!=11 ? 0 : n % 10>=2 "
 "&& n % 10<=4 && (n % 100<10 || n % 100>=20) ? 1 : 2);\\n\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Программа запуска Tor Browser"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Написана Micah Lee и распространяется по лицензии MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "версия {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Ошибка создания {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "Нельзя записать в {0}"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Нельзя создать каталог {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Создание домашнего каталога GnuPG"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Не удалось импортировать отпечаток ключа: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Не все ключи были успешно импортированы!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Загрузка Tor Browser в первый раз."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Ваша версия Tor Browser устарела. Загрузка новой версии."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Загрузка через Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Запуск"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Да"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Выход"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Отмена"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Загрузка"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Последняя версия: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Ошибка получения версии Tor Browser."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Сверка подписи"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Распаковка"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Запуск"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Повторная загрузка"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "через Tor"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Загружено"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Установка"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Программа запуска Tor Browser не понимает формат файла {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -147,19 +148,20 @@ msgstr ""
 "Вы установили новую версию Tor Browser раньше, чем это должно быть. Это "
 "может быть атакой!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Повторная загрузка Tor Browser"
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Ошибка загрузки:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Вы используете нестандартное зеркало"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Хотите вернуться к стандартному?"
 
@@ -167,7 +169,7 @@ msgstr "Хотите вернуться к стандартному?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Попробовать загрузить английскую версию Tor Browser?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -180,11 +182,11 @@ msgstr ""
 "\n"
 "Возможно, вы под атакой."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Загрузить снова через Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -200,7 +202,7 @@ msgstr ""
 "\n"
 "Не удалось загрузить через Tor. Проверьте, что Tor запущен и верно настроен."
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -215,11 +217,11 @@ msgstr ""
 "\n"
 "Вы подключены к сети?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Настройки программы запуска Tor Browser"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Загружать через Tor"
 
@@ -227,33 +229,53 @@ msgstr "Загружать через Tor"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Загружать только английскую версию Tor Browser"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Сервер Tor"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Статус: установлен"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Статус: не установлен"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Установить Tor Browser"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Переустановить Tor Browser"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Зеркало"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Сохранить и выйти"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2018-11-10 11:36+0100\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: Swedish\n"
@@ -18,127 +18,128 @@ msgstr ""
 "X-Generator: Poedit 2.2\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser Launcher"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Av Mika Lee, licensierad under MIT"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "version {0}"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "Ett fel uppstod vid skapande {0}"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "{0} är inte skrivbar"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "Kan inte att skapa katalog {0}"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "Skapa GnuPG-homedir"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "Kunde inte importera nyckel med fingeravtryck: %s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "Inte alla nycklar importerades!"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Hämtar Tor Browser för första gången."
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Din version av Tor Browser är föråldrad. Hämta den senaste versionen."
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Hämtar över Tor"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Börja"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Ja"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Avsluta"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "Avbryt"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "Hämtar"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "Senaste versionen: {}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Fel vid detektering av Tor Browser-versionen."
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "Verifierar signaturen"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Packar upp"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Körs"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "Börja hämtningen igen"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(över Tor)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "Hämtad"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Installerar"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor Browser Launcher förstår inte filformatet {0}"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -146,19 +147,20 @@ msgstr ""
 "Den version av Tor Browser du har installerat är tidigare än den borde vara, "
 "vilket kan vara ett tecken på en attack!"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Hämtar Tor Browser igen."
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "Hämtningsfel:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Du använder för närvarande en icke-standardspegel"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Vill du byta tillbaka till standard?"
 
@@ -166,7 +168,7 @@ msgstr "Vill du byta tillbaka till standard?"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Vill du prova den engelska versionen av Tor Browser istället?"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -179,11 +181,11 @@ msgstr ""
 "\n"
 "Du kan vara under attack."
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Försök att hämta igen med Tor?"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -200,7 +202,7 @@ msgstr ""
 "Försöker att hämta över Tor. Är du säker på att Tor är korrekt konfigurerad "
 "och körs?"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -215,11 +217,11 @@ msgstr ""
 "\n"
 "Är du ansluten till internet?"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Inställningar för Tor Browser Launcher"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Hämta över Tor-system"
 
@@ -227,38 +229,57 @@ msgstr "Hämta över Tor-system"
 msgid "Force downloading English version of Tor Browser"
 msgstr "Tvinga att hämta engelsk version av Tor Browser"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor-server"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Tillstånd: Installerad"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Tillstånd: Inte installerad"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Installera Tor Browser"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Installera om Tor Browser"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Spegel"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Spara && avsluta"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""
 
 #~ msgid ""
 #~ "The python-txsocksx package is missing, downloads will not happen over tor"
 #~ msgstr ""
-#~ ""
 #~ "Python-txsocksx-paketet saknas, hämtningar kommer inte att hända över Tor."
 
 #~ msgid "DNS Lookup Error"
@@ -268,8 +289,8 @@ msgstr "Spara && avsluta"
 #~ "The SSL certificate served by https://www.torproject.org is invalid! You "
 #~ "may be under attack."
 #~ msgstr ""
-#~ "SSL-certifikatet som betjänas av https://www.torproject.org är ogiltig!"
-#~ "Du kan vara under attack."
+#~ "SSL-certifikatet som betjänas av https://www.torproject.org är ogiltig!Du "
+#~ "kan vara under attack."
 
 #~ msgid "Error connecting to Tor at {0}"
 #~ msgstr "Fel vid anslutning till Tor på {0}"
@@ -287,8 +308,7 @@ msgstr "Spara && avsluta"
 
 #~ msgid ""
 #~ "The python-pygame package is missing, the modem sound is unavailable."
-#~ msgstr ""
-#~ "Python-pygame-paketet saknas, modemljudet är otillgängligt."
+#~ msgstr "Python-pygame-paketet saknas, modemljudet är otillgängligt."
 
 #~ msgid ""
 #~ "This option is only available when using a system wide Tor installation."

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-27 08:41+0300\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2022-03-06 09:00+0300\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
 "Language-Team: Turkish <tr>\n"
@@ -17,127 +17,128 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
-#: common.py:159
-#, python-brace-format
-msgid "Error creating {0}"
-msgstr "{0} oluşturulurken hata"
-
-#: common.py:270
-#, python-brace-format
-msgid "Cannot create directory {0}"
-msgstr "{0} dizini oluşturulamıyor"
-
-#: common.py:273
-#, python-brace-format
-msgid "{0} is not writable"
-msgstr "{0} yazılabilir değil"
-
-#: common.py:280
-msgid "Creating GnuPG homedir"
-msgstr "GnuPG ana dizini oluşturuluyor"
-
-#: common.py:371
-#, python-format
-msgid "Could not import key with fingerprint: %s."
-msgstr "%s parmak izine sahip anahtar içe aktarılamadı."
-
-#: common.py:378
-msgid "Not all keys were imported successfully!"
-msgstr "Tüm anahtarlar başarıyla içe aktarılmadı!"
-
-#: __init__.py:71 launcher.py:528
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor Browser Başlatıcı"
 
-#: __init__.py:72
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "Micah Lee tarafından, MIT lisansı altında lisanslandı"
 
-#: __init__.py:73
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "sürüm {0}"
 
-#: launcher.py:86
+#: common.py:100 common.py:92
+#, python-brace-format
+msgid "Error creating {0}"
+msgstr "{0} oluşturulurken hata"
+
+#: common.py:102 common.py:180 common.py:228
+#, python-brace-format
+msgid "{0} is not writable"
+msgstr "{0} yazılabilir değil"
+
+#: common.py:177 common.py:225
+#, python-brace-format
+msgid "Cannot create directory {0}"
+msgstr "{0} dizini oluşturulamıyor"
+
+#: common.py:187 common.py:235
+msgid "Creating GnuPG homedir"
+msgstr "GnuPG ana dizini oluşturuluyor"
+
+#: common.py:254 common.py:326
+#, python-format
+msgid "Could not import key with fingerprint: %s."
+msgstr "%s parmak izine sahip anahtar içe aktarılamadı."
+
+#: common.py:259 common.py:333
+msgid "Not all keys were imported successfully!"
+msgstr "Tüm anahtarlar başarıyla içe aktarılmadı!"
+
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "Tor Browser ilk kez indiriliyor."
 
-#: launcher.py:89
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "Tor Browser sürümünüz güncel değil. En yeni sürüm indiriliyor."
 
-#: launcher.py:110
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "Tor üzerinden indiriliyor"
 
-#: launcher.py:121
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor Browser"
 
-#: launcher.py:140
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "Başlat"
 
-#: launcher.py:190
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "Evet"
 
-#: launcher.py:194
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "Çıkış"
 
-#: launcher.py:208 settings.py:147
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "İptal"
 
-#: launcher.py:247 launcher.py:268 launcher.py:277 launcher.py:316
-#: launcher.py:319
+#: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "İndiriliyor"
 
-#: launcher.py:258
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "En son sürüm: {}"
 
-#: launcher.py:262
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "Tor Browser sürümü algılanırken hata oluştu."
 
-#: launcher.py:292 launcher.py:397
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "İmza Doğrulanıyor"
 
-#: launcher.py:296
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "Çıkartılıyor"
 
-#: launcher.py:300
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "Çalıştırılıyor"
 
-#: launcher.py:304
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "İndirme yeniden başlatılıyor"
 
-#: launcher.py:316 launcher.py:335
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(Tor üzerinden)"
 
-#: launcher.py:331
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "İndirildi"
 
-#: launcher.py:439
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "Kuruluyor"
 
-#: launcher.py:448
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor Browser Başlatıcı, {0} dosya biçimini anlamıyor"
 
-#: launcher.py:479
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
@@ -145,27 +146,28 @@ msgstr ""
 "Kurduğunuz Tor Browser sürümü olması gerekenden daha eski ve bu bir saldırı "
 "işareti olabilir!"
 
-#: launcher.py:496
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "Tor Browser tekrar indiriliyor."
 
-#: launcher.py:568 launcher.py:582 launcher.py:591
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "İndirme Hatası:"
 
-#: launcher.py:570
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "Şu anda öntanımlı olmayan bir yansı kullanıyorsunuz"
 
-#: launcher.py:572
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "Öntanımlı olana geri dönmek ister misiniz?"
 
-#: launcher.py:585
+#: launcher.py:527
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "Bunun yerine Tor Browser'ın İngilizce sürümünü denemek ister misiniz?"
 
-#: launcher.py:607
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -178,11 +180,11 @@ msgstr ""
 "\n"
 "Saldırı altında olabilirsiniz."
 
-#: launcher.py:610
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "Tor kullanarak indirme tekrar denensin mi?"
 
-#: launcher.py:620
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -199,7 +201,7 @@ msgstr ""
 "Tor üzerinden indirmeye çalışılıyor. Tor'un doğru yapılandırıldığından ve "
 "çalıştığından emin misiniz?"
 
-#: launcher.py:626
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -214,42 +216,62 @@ msgstr ""
 "\n"
 "İnternete bağlı mısınız?"
 
-#: settings.py:47
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Tor Browser Başlatıcı Ayarları"
 
-#: settings.py:51
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "Sistem Tor'u üzerinden indir"
 
-#: settings.py:59
+#: settings.py:57
 msgid "Force downloading English version of Tor Browser"
 msgstr "Tor Browser'ın İngilizce sürümünü indirmeye zorla"
 
-#: settings.py:69
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor sunucusu"
 
-#: settings.py:85
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "Durum: Kurulu"
 
-#: settings.py:87
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "Durum: Kurulu Değil"
 
-#: settings.py:90
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "Tor Browser'ı Kur"
 
-#: settings.py:97
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "Tor Browser'ı Yeniden Kur"
 
-#: settings.py:122
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "Yansı"
 
-#: settings.py:140
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "Kaydet && Çık"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: 2020-04-22 23:31+0800\n"
 "Last-Translator: Koala Yeung <koalay@gmail.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -18,145 +18,147 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr "Tor 瀏覽器啟動程式"
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr "由 Micah Lee 編寫，以 MIT 特許授權發佈"
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr "{0} 版"
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr "生成 {0} 時發生問題"
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr "無法寫入 {0}"
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr "無法生成 {0} 目錄"
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr "生成 GnuPG 目錄"
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr "無法以指紋匯入加密金鑰︰%s."
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr "只有部份加密金鑰加入成功！"
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr "第一次下載 Tor 瀏覽器。"
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr "你目前的 Tor 瀏覽器不是最新的，正下載最新版本。"
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr "透過 Tor 網絡下載"
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr "Tor 瀏覽器"
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr "開始"
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr "是"
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr "離開"
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr "取消"
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr "下載中"
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr "最新版本︰{}"
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr "偵測 Tor 瀏覽器版本時發生錯誤。"
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr "正在檢查數位簽章"
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr "正在解開"
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr "執行中"
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr "從新開始下載"
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr "(透過 Tor 網絡)"
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr "已下載"
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr "正在安裝"
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr "Tor 瀏覽器啟動程式不了解 {0} 的檔案格式"
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr "你已安裝的 Tor 瀏覽器版本比預期的版本早期，這表示你的電腦可能被入侵！"
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr "重新下載 Tor 瀏覽器。"
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr "下載錯誤:"
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr "你目前正在使用非預設的鏡像"
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr "你想改為使用預設的嗎？"
 
@@ -164,7 +166,7 @@ msgstr "你想改為使用預設的嗎？"
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr "你要試試改為下載英文版 Tor 瀏覽器嗎？"
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -177,11 +179,11 @@ msgstr ""
 "\n"
 "你可能正被入侵。"
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr "要試試改用 Tor 網絡重新下載嗎？"
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -197,7 +199,7 @@ msgstr ""
 "\n"
 "請試試經由 Tor 網絡下載。你肯定你的 Tor 有正確被下載和執行嗎？"
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -212,11 +214,11 @@ msgstr ""
 "\n"
 "請問你是否有連上互聯網？"
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr "Tor 瀏覽器啟動程式設定"
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr "透過系統的 Tor 網絡下載"
 
@@ -224,30 +226,50 @@ msgstr "透過系統的 Tor 網絡下載"
 msgid "Force downloading English version of Tor Browser"
 msgstr "強制下載英文版本的 Tor 瀏覽器"
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr "Tor 伺服器"
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr "狀態︰已安裝"
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr "狀態︰未安裝"
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr "安裝 Tor 瀏覽器"
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr "重新安裝 Tor 瀏覽器"
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr "鏡像"
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
 msgstr "儲存及離開"
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
+msgstr ""

--- a/torbrowser_launcher.pot
+++ b/torbrowser_launcher.pot
@@ -8,154 +8,156 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-23 15:47-0700\n"
+"POT-Creation-Date: 2023-08-27 18:18-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: __init__.py:65 launcher.py:470
+#: __init__.py:65 launcher.py:470 __init__.py:71 launcher.py:519
 msgid "Tor Browser Launcher"
 msgstr ""
 
-#: __init__.py:66
+#: __init__.py:66 __init__.py:72
 msgid "By Micah Lee, licensed under MIT"
 msgstr ""
 
-#: __init__.py:67
+#: __init__.py:67 __init__.py:73
 #, python-brace-format
 msgid "version {0}"
 msgstr ""
 
-#: common.py:100
+#: common.py:100 common.py:92
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr ""
 
-#: common.py:102 common.py:180
+#: common.py:102 common.py:180 common.py:228
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr ""
 
-#: common.py:177
+#: common.py:177 common.py:225
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr ""
 
-#: common.py:187
+#: common.py:187 common.py:235
 msgid "Creating GnuPG homedir"
 msgstr ""
 
-#: common.py:254
+#: common.py:254 common.py:326
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr ""
 
-#: common.py:259
+#: common.py:259 common.py:333
 msgid "Not all keys were imported successfully!"
 msgstr ""
 
-#: launcher.py:83
+#: launcher.py:83 launcher.py:86
 msgid "Downloading Tor Browser for the first time."
 msgstr ""
 
-#: launcher.py:85
+#: launcher.py:85 launcher.py:89
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 
-#: launcher.py:100
+#: launcher.py:100 launcher.py:110
 msgid "Downloading over Tor"
 msgstr ""
 
-#: launcher.py:111
+#: launcher.py:111 launcher.py:121
 msgid "Tor Browser"
 msgstr ""
 
-#: launcher.py:128
+#: launcher.py:128 launcher.py:140
 msgid "Start"
 msgstr ""
 
-#: launcher.py:174
+#: launcher.py:174 launcher.py:190
 msgid "Yes"
 msgstr ""
 
-#: launcher.py:178
+#: launcher.py:178 launcher.py:194
 msgid "Exit"
 msgstr ""
 
-#: launcher.py:192 settings.py:136
+#: launcher.py:192 settings.py:136 launcher.py:208 settings.py:135
 msgid "Cancel"
 msgstr ""
 
 #: launcher.py:231 launcher.py:245 launcher.py:249 launcher.py:279
-#: launcher.py:281
+#: launcher.py:281 launcher.py:266 launcher.py:275 launcher.py:314
+#: launcher.py:317
 msgid "Downloading"
 msgstr ""
 
-#: launcher.py:238
+#: launcher.py:238 launcher.py:256
 msgid "Latest version: {}"
 msgstr ""
 
-#: launcher.py:241
+#: launcher.py:241 launcher.py:260
 msgid "Error detecting Tor Browser version."
 msgstr ""
 
-#: launcher.py:256 launcher.py:357
+#: launcher.py:256 launcher.py:357 launcher.py:290 launcher.py:388
 msgid "Verifying Signature"
 msgstr ""
 
-#: launcher.py:260
+#: launcher.py:260 launcher.py:294
 msgid "Extracting"
 msgstr ""
 
-#: launcher.py:264
+#: launcher.py:264 launcher.py:298
 msgid "Running"
 msgstr ""
 
-#: launcher.py:268
+#: launcher.py:268 launcher.py:302
 msgid "Starting download over again"
 msgstr ""
 
-#: launcher.py:279 launcher.py:295
+#: launcher.py:279 launcher.py:295 launcher.py:314 launcher.py:333
 msgid "(over Tor)"
 msgstr ""
 
-#: launcher.py:293
+#: launcher.py:293 launcher.py:329
 msgid "Downloaded"
 msgstr ""
 
-#: launcher.py:393
+#: launcher.py:393 launcher.py:430
 msgid "Installing"
 msgstr ""
 
-#: launcher.py:401
+#: launcher.py:401 launcher.py:439
 #, python-brace-format
 msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr ""
 
-#: launcher.py:427
+#: launcher.py:427 launcher.py:470
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
 
-#: launcher.py:446
+#: launcher.py:446 launcher.py:487
 msgid "Downloading Tor Browser over again."
 msgstr ""
 
-#: launcher.py:516 launcher.py:525 launcher.py:533
+#: launcher.py:516 launcher.py:525 launcher.py:533 launcher.py:560
+#: launcher.py:568
 msgid "Download Error:"
 msgstr ""
 
-#: launcher.py:517
+#: launcher.py:517 launcher.py:562
 msgid "You are currently using a non-default mirror"
 msgstr ""
 
-#: launcher.py:518
+#: launcher.py:518 launcher.py:564
 msgid "Would you like to switch back to the default?"
 msgstr ""
 
@@ -163,7 +165,7 @@ msgstr ""
 msgid "Would you like to try the English version of Tor Browser instead?"
 msgstr ""
 
-#: launcher.py:548
+#: launcher.py:548 launcher.py:584
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -172,11 +174,11 @@ msgid ""
 "You may be under attack."
 msgstr ""
 
-#: launcher.py:550
+#: launcher.py:550 launcher.py:587
 msgid "Try the download again using Tor?"
 msgstr ""
 
-#: launcher.py:559
+#: launcher.py:559 launcher.py:597
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -187,7 +189,7 @@ msgid ""
 "running?"
 msgstr ""
 
-#: launcher.py:563
+#: launcher.py:563 launcher.py:603
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -197,11 +199,11 @@ msgid ""
 "Are you connected to the internet?"
 msgstr ""
 
-#: settings.py:46
+#: settings.py:46 settings.py:47
 msgid "Tor Browser Launcher Settings"
 msgstr ""
 
-#: settings.py:50
+#: settings.py:50 settings.py:51
 msgid "Download over system Tor"
 msgstr ""
 
@@ -209,30 +211,50 @@ msgstr ""
 msgid "Force downloading English version of Tor Browser"
 msgstr ""
 
-#: settings.py:66
+#: settings.py:66 settings.py:58
 msgid "Tor server"
 msgstr ""
 
-#: settings.py:82
+#: settings.py:82 settings.py:73
 msgid "Status: Installed"
 msgstr ""
 
-#: settings.py:84
+#: settings.py:84 settings.py:75
 msgid "Status: Not Installed"
 msgstr ""
 
-#: settings.py:87
+#: settings.py:87 settings.py:78
 msgid "Install Tor Browser"
 msgstr ""
 
-#: settings.py:92
+#: settings.py:92 settings.py:85
 msgid "Reinstall Tor Browser"
 msgstr ""
 
-#: settings.py:115
+#: settings.py:115 settings.py:110
 msgid "Mirror"
 msgstr ""
 
-#: settings.py:131
+#: settings.py:131 settings.py:128
 msgid "Save && Exit"
+msgstr ""
+
+#: common.py:195
+#, python-brace-format
+msgid "Deleted {0}"
+msgstr ""
+
+#: common.py:200
+#, python-brace-format
+msgid "Could not remove {0} due a system error: {1}"
+msgstr ""
+
+#: common.py:209
+#, python-brace-format
+msgid "Could not move {0} to {1} due an error: {2}"
+msgstr ""
+
+#: common.py:215
+#, python-brace-format
+msgid "Renamed {0} to {1}"
 msgstr ""


### PR DESCRIPTION
I fixed a crash that happens when a locale folder from before Tor Browser 12.0 exists (ex.: `tor-browser_es-ES`) at the same time that `tor-browser` folder exists.

And due I added new strings I updated the `.pot` and `.po` files.

Sorry for my bad English.