### PR TITLE
Migrate code from PyQt5 to PySide6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ Browser.
     install_requires=[
         "gpg",
         "packaging",
-        "PyQt5",
+        "PySide6",
         "requests",
         "PySocks",
     ],

--- a/torbrowser_launcher/__init__.py
+++ b/torbrowser_launcher/__init__.py
@@ -31,7 +31,7 @@ import sys
 import argparse
 import signal
 
-from PyQt5 import QtCore, QtWidgets
+from PySide6 import QtWidgets
 
 from .common import Common, SHARE
 from .settings import Settings
@@ -44,7 +44,6 @@ class Application(QtWidgets.QApplication):
     """
 
     def __init__(self):
-        self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
         QtWidgets.QApplication.__init__(self, sys.argv)
         self.installEventFilter(self)
 
@@ -87,11 +86,11 @@ def main():
         gui = Launcher(common, app, url_list)
 
     # Center the window
-    desktop = app.desktop()
+    screen_size = app.primaryScreen().size()
     window_size = gui.size()
     gui.move(
-        (desktop.width() - window_size.width()) // 2,
-        (desktop.height() - window_size.height()) // 2,
+        (screen_size.width() - window_size.width()) // 2,
+        (screen_size.height() - window_size.height()) // 2,
     )
     gui.show()
 

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -39,7 +39,7 @@ import shutil
 import xml.etree.ElementTree as ET
 from packaging import version
 
-from PyQt5 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 
 class TryStableException(Exception):
@@ -531,9 +531,9 @@ class DownloadThread(QtCore.QThread):
     Download a file in a separate thread.
     """
 
-    progress_update = QtCore.pyqtSignal(int, int)
-    download_complete = QtCore.pyqtSignal()
-    download_error = QtCore.pyqtSignal(str, str)
+    progress_update = QtCore.Signal(int, int)
+    download_complete = QtCore.Signal()
+    download_error = QtCore.Signal(str, str)
 
     def __init__(self, common, url, path):
         super(DownloadThread, self).__init__()
@@ -614,8 +614,8 @@ class VerifyThread(QtCore.QThread):
     Verify the signature in a separate thread
     """
 
-    success = QtCore.pyqtSignal()
-    error = QtCore.pyqtSignal(str)
+    success = QtCore.Signal()
+    error = QtCore.Signal(str)
 
     def __init__(self, common):
         super(VerifyThread, self).__init__()
@@ -656,8 +656,8 @@ class ExtractThread(QtCore.QThread):
     Extract the tarball in a separate thread
     """
 
-    success = QtCore.pyqtSignal()
-    error = QtCore.pyqtSignal()
+    success = QtCore.Signal()
+    error = QtCore.Signal()
 
     def __init__(self, common):
         super(ExtractThread, self).__init__()

--- a/torbrowser_launcher/settings.py
+++ b/torbrowser_launcher/settings.py
@@ -29,7 +29,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 import subprocess
 import shutil
 
-from PyQt5 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 
 class Settings(QtWidgets.QMainWindow):


### PR DESCRIPTION
This pull-request aims to migrate torbrowser-launcher from `Qt5` to `Qt6`.

---

The next step is to update deps in `BUILD.md`, `build_rpm.sh`, and `stdeb.cfg` to install `python3-pyside6` rather than `python3-pyqt5`. But for the time beeping, Debian doesn't ship `pyside6` in there repos and so does Fedora.

By the way according to my knowledge, torbrowser-launcher is currently violating PyQt5's `GPLv3` license by being licensed under `MIT` (unless the commercial license is used). So we must use `PySide6` or chagne torbrowser-launcher's license to GPLv3.

Should we just don't care about GPLv3, FOSS, and official support and use `PyQt6` rather than `PySide6` since `PyQt6` is already available in Debian Bookworm and Fedora?

> Read More: https://www.pythonguis.com/faq/pyqt6-vs-pyside6/