### PR TITLE
Correctly report errors from ExtractThread

### DIFF
--- a/torbrowser_launcher.pot
+++ b/torbrowser_launcher.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 17:04+0100\n"
+"POT-Creation-Date: 2026-07-06 16:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,154 +17,150 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: __init__.py:76 launcher.py:520
+#: __init__.py:75 launcher.py:521
 msgid "Tor Browser Launcher"
 msgstr ""
 
-#: __init__.py:77
+#: __init__.py:76
 msgid "By Micah Lee & Tor Project, licensed under MIT"
 msgstr ""
 
-#: __init__.py:78
+#: __init__.py:77
 #, python-brace-format
 msgid "version {0}"
 msgstr ""
 
-#: common.py:90
+#: common.py:81
 #, python-brace-format
 msgid "Error creating {0}"
 msgstr ""
 
-#: common.py:187
+#: common.py:178
 #, python-brace-format
 msgid "Renamed {0} to {1}"
 msgstr ""
 
-#: common.py:201
+#: common.py:192
 #, python-brace-format
 msgid "Cannot create directory {0}"
 msgstr ""
 
-#: common.py:204
+#: common.py:195
 #, python-brace-format
 msgid "{0} is not writable"
 msgstr ""
 
-#: common.py:211
+#: common.py:202
 msgid "Creating GnuPG homedir"
 msgstr ""
 
-#: common.py:302
+#: common.py:293
 #, python-format
 msgid "Could not import key with fingerprint: %s."
 msgstr ""
 
-#: common.py:309
+#: common.py:300
 msgid "Not all keys were imported successfully!"
 msgstr ""
 
-#: launcher.py:87
+#: launcher.py:88
 msgid "Downloading Tor Browser for the first time."
 msgstr ""
 
-#: launcher.py:90
+#: launcher.py:91
 msgid ""
 "Your version of Tor Browser is out-of-date. Downloading the newest version."
 msgstr ""
 
-#: launcher.py:111
+#: launcher.py:112
 msgid "Downloading over Tor"
 msgstr ""
 
-#: launcher.py:122
+#: launcher.py:123
 msgid "Tor Browser"
 msgstr ""
 
-#: launcher.py:141
+#: launcher.py:142
 msgid "Start"
 msgstr ""
 
-#: launcher.py:191
+#: launcher.py:192
 msgid "Yes"
 msgstr ""
 
-#: launcher.py:195
+#: launcher.py:196
 msgid "Exit"
 msgstr ""
 
-#: launcher.py:209 settings.py:136
+#: launcher.py:210 settings.py:136
 msgid "Cancel"
 msgstr ""
 
-#: launcher.py:246 launcher.py:267 launcher.py:276 launcher.py:315
-#: launcher.py:318
+#: launcher.py:247 launcher.py:268 launcher.py:277 launcher.py:316
+#: launcher.py:319
 msgid "Downloading"
 msgstr ""
 
-#: launcher.py:257
+#: launcher.py:258
+#, python-brace-format
 msgid "Latest version: {}"
 msgstr ""
 
-#: launcher.py:261
+#: launcher.py:262
 msgid "Error detecting Tor Browser version."
 msgstr ""
 
-#: launcher.py:291 launcher.py:389
+#: launcher.py:292 launcher.py:392
 msgid "Verifying Signature"
 msgstr ""
 
-#: launcher.py:295
+#: launcher.py:296
 msgid "Extracting"
 msgstr ""
 
-#: launcher.py:299
+#: launcher.py:300
 msgid "Running"
 msgstr ""
 
-#: launcher.py:303
+#: launcher.py:304
 msgid "Starting download over again"
 msgstr ""
 
-#: launcher.py:315 launcher.py:334
+#: launcher.py:316 launcher.py:335
 msgid "(over Tor)"
 msgstr ""
 
-#: launcher.py:330
+#: launcher.py:331
 msgid "Downloaded"
 msgstr ""
 
-#: launcher.py:431
+#: launcher.py:435
 msgid "Installing"
 msgstr ""
 
-#: launcher.py:440
-#, python-brace-format
-msgid "Tor Browser Launcher doesn't understand the file format of {0}"
-msgstr ""
-
-#: launcher.py:471
+#: launcher.py:472
 msgid ""
 "The version of Tor Browser you have installed is earlier than it should be, "
 "which could be a sign of an attack!"
 msgstr ""
 
-#: launcher.py:488
+#: launcher.py:489
 msgid "Downloading Tor Browser over again."
 msgstr ""
 
-#: launcher.py:561 launcher.py:569
+#: launcher.py:562 launcher.py:570
 msgid "Download Error:"
 msgstr ""
 
-#: launcher.py:563
+#: launcher.py:564
 msgid "You are currently using a non-default mirror"
 msgstr ""
 
-#: launcher.py:565
+#: launcher.py:566
 msgid "Would you like to switch back to the default?"
 msgstr ""
 
-#: launcher.py:585
+#: launcher.py:586
 #, python-brace-format
 msgid ""
 "Invalid SSL certificate for:\n"
@@ -173,11 +169,11 @@ msgid ""
 "You may be under attack."
 msgstr ""
 
-#: launcher.py:588
+#: launcher.py:589
 msgid "Try the download again using Tor?"
 msgstr ""
 
-#: launcher.py:598
+#: launcher.py:599
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -188,7 +184,7 @@ msgid ""
 "running?"
 msgstr ""
 
-#: launcher.py:604
+#: launcher.py:605
 #, python-brace-format
 msgid ""
 "Error starting download:\n"
@@ -196,6 +192,11 @@ msgid ""
 "{0}\n"
 "\n"
 "Are you connected to the internet?"
+msgstr ""
+
+#: launcher.py:683
+#, python-brace-format
+msgid "Tor Browser Launcher doesn't understand the file format of {0}"
 msgstr ""
 
 #: settings.py:48

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -440,11 +440,7 @@ class Launcher(QtWidgets.QMainWindow):
         def error(message):
             self.set_state(
                 "task",
-                _(
-                    "Tor Browser Launcher doesn't understand the file format of {0}".format(
-                        self.common.paths["tarball_file"]
-                    )
-                ),
+                message,
                 ["start_over"],
                 False,
             )
@@ -663,31 +659,30 @@ class ExtractThread(QtCore.QThread):
     """
 
     success = QtCore.Signal()
-    error = QtCore.Signal()
+    error = QtCore.Signal(str)
 
     def __init__(self, common):
         super(ExtractThread, self).__init__()
         self.common = common
 
     def run(self):
-        extracted = False
         try:
             if self.common.paths["tarball_file"][-2:] == "xz":
                 # if tarball is .tar.xz
                 xz = lzma.LZMAFile(self.common.paths["tarball_file"])
                 tf = tarfile.open(fileobj=xz)
                 tf.extractall(self.common.paths["tbb"]["dir"])
-                extracted = True
-            else:
+                self.success.emit()
+            elif tarfile.is_tarfile(self.common.paths["tarball_file"]):
                 # if tarball is .tar.gz
-                if tarfile.is_tarfile(self.common.paths["tarball_file"]):
-                    tf = tarfile.open(self.common.paths["tarball_file"])
-                    tf.extractall(self.common.paths["tbb"]["dir"])
-                    extracted = True
-        except:
-            pass
-
-        if extracted:
-            self.success.emit()
-        else:
-            self.error.emit()
+                tf = tarfile.open(self.common.paths["tarball_file"])
+                tf.extractall(self.common.paths["tbb"]["dir"])
+                self.success.emit()
+            else:
+                self.error.emit(_(
+                    "Tor Browser Launcher doesn't understand the file format of {0}".format(
+                        self.common.paths["tarball_file"]
+                    )
+                ))
+        except Exception as e:
+            self.error.emit(str(e))


### PR DESCRIPTION
When trying to installing torbrowser, it would hit an exception whose nature is ignored (problem 1) simply sending an error signal

```py
        if extracted:
            self.success.emit()
        else:
            self.error.emit()
```

The handler on the other side though requires an argument (`message`) (problem 2)

```py
        t = ExtractThread(self.common)
        t.error.connect(error)  # def error(message: Unknown) -> None
        t.success.connect(success)
```

This `error` argument is unused (problem 3), assuming that the extraction failed due to not being able to figure out the format

```py
        def error(message):
            self.set_state(
                "task",
                _(
                    "Tor Browser Launcher doesn't understand the file format of {0}".format(
                        self.common.paths["tarball_file"]
                    )
                ),
                ["start_over"],
                False,
            )
```

My setup has torbrowser's config linked to a different folder (don't question it), the extractor thinks the tar is trying to write files outside the destination and throws. That is how I stumbled upon this
